### PR TITLE
Add support for interfaces in the expectsParameters check on MethodFi…

### DIFF
--- a/src/Facades/Verbs.php
+++ b/src/Facades/Verbs.php
@@ -11,7 +11,7 @@ use Thunk\Verbs\Lifecycle\Broker;
  * @method static bool isReplaying()
  * @method static void unlessReplaying(callable $callback)
  * @method static bool isReplaying()
- * @method static int|string toId($id)
+ * @method static int|string|null toId($id)
  * @method static Event fire(Event $event)
  */
 class Verbs extends Facade

--- a/src/Support/MethodFinder.php
+++ b/src/Support/MethodFinder.php
@@ -76,7 +76,6 @@ class MethodFinder
 
             $direct_matches = $expected->intersect($this->types);
 
-
             if ($direct_matches->isNotEmpty()) {
                 return true;
             }
@@ -91,7 +90,7 @@ class MethodFinder
             if ($interface_matches->isNotEmpty()) {
                 return true;
             }
-            
+
             return false;
         }
 


### PR DESCRIPTION
Previously you couldn't type-hint an interface on an `SomeState::applySomething()` method and have it match an interface. This fixes that.