### PR TITLE
Add Livewire support to commit Verbs just before render

### DIFF
--- a/src/Livewire/SupportVerbs.php
+++ b/src/Livewire/SupportVerbs.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Thunk\Verbs\Livewire;
+
+use Livewire\ComponentHook;
+use Thunk\Verbs\Facades\Verbs;
+
+class SupportVerbs extends ComponentHook
+{
+    function render()
+    {
+        Verbs::commit();
+    }
+}

--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -14,6 +14,7 @@ use Thunk\Verbs\Lifecycle\EventStore;
 use Thunk\Verbs\Lifecycle\Queue as EventQueue;
 use Thunk\Verbs\Lifecycle\SnapshotStore;
 use Thunk\Verbs\Lifecycle\StateManager;
+use Thunk\Verbs\Livewire\SupportVerbs;
 use Thunk\Verbs\Support\EventSerializer;
 use Thunk\Verbs\Support\EventStateRegistry;
 use Thunk\Verbs\Support\StateSerializer;
@@ -64,8 +65,8 @@ class VerbsServiceProvider extends PackageServiceProvider
     {
         parent::boot();
 
-        if (app()->has('livewire')) {
-            app('livewire')->componentHook(\Thunk\Verbs\Livewire\SupportVerbs::class);
+        if ($this->app->has('livewire')) {
+            $this->app->make('livewire')->componentHook(SupportVerbs::class);
         }
 
         $this->app->terminating(function () {

--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -64,6 +64,10 @@ class VerbsServiceProvider extends PackageServiceProvider
     {
         parent::boot();
 
+        if (app()->has('livewire')) {
+            app('livewire')->componentHook(\Thunk\Verbs\Livewire\SupportVerbs::class);
+        }
+
         $this->app->terminating(function () {
             app(Broker::class)->commit();
         });


### PR DESCRIPTION
This PR adds Livewire support to Verbs, to ensure Verbs has been committed before Livewire renders the view.

@DanielCoulbourne was also experimenting with serialising a state object inside a Livewire component using Wireables, but I think we should change it to use a Synth and add it to this PR.