### PR TITLE
Add a replay command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "glhd/bits": "^0.2",
         "illuminate/contracts": "^10.0",
         "internachi/modular": "^2.0",
+        "laravel/prompts": "^0.1.13",
         "spatie/laravel-package-tools": "^1.14.0",
         "symfony/property-access": "^6.2",
         "symfony/serializer": "^6.3"

--- a/config/verbs.php
+++ b/config/verbs.php
@@ -1,4 +1,32 @@
 <?php
 
 return [
+    'replay' => [
+        /**
+         * When your models don't reside in the default laravel structure you can set a
+         * different base directories to check.
+         */
+        'base_directories' => [base_path()],
+
+        /**
+         * When your models don't reside in the default App namespace you can set different
+         * namespaces to check.
+         */
+        'root_namespaces' => ['App\\'],
+
+        /*
+        * Within these paths, the package will search for models that are replayable.
+        */
+        'paths' => [
+            app_path(),
+        ],
+
+        /*
+        * Only models that extend from one of the base models defined here will
+        * be included replay discovery.
+        */
+        'base_models' => [
+            Illuminate\Database\Eloquent\Model::class,
+        ],
+    ],
 ];

--- a/examples/Bank/src/Models/Account.php
+++ b/examples/Bank/src/Models/Account.php
@@ -5,8 +5,10 @@ namespace Thunk\Verbs\Examples\Bank\Models;
 use Glhd\Bits\Database\HasSnowflakes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
+use Thunk\Verbs\Attributes\Autodiscovery\Replayable;
 use Thunk\Verbs\Examples\Bank\Events\AccountOpened;
 
+#[Replayable(truncate: true)]
 class Account extends Model
 {
     use HasSnowflakes;

--- a/examples/Subscriptions/src/Models/Subscription.php
+++ b/examples/Subscriptions/src/Models/Subscription.php
@@ -4,8 +4,10 @@ namespace Thunk\Verbs\Examples\Subscriptions\Models;
 
 use Glhd\Bits\Database\HasSnowflakes;
 use Illuminate\Database\Eloquent\Model;
+use Thunk\Verbs\Attributes\Autodiscovery\Replayable;
 use Thunk\Verbs\Examples\Subscriptions\Events\SubscriptionCancelled;
 
+#[Replayable]
 class Subscription extends Model
 {
     use HasSnowflakes;

--- a/src/Attributes/Autodiscovery/Replayable.php
+++ b/src/Attributes/Autodiscovery/Replayable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Thunk\Verbs\Attributes\Autodiscovery;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Replayable
+{
+    public function __construct(public bool $truncate = true)
+    {
+    }
+}

--- a/src/Commands/ReplayEventsCommand.php
+++ b/src/Commands/ReplayEventsCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Thunk\Verbs\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Thunk\Verbs\Facades\Verbs;
+use Thunk\Verbs\Support\ModelFinder;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\multiselect;
+
+class ReplayEventsCommand extends Command
+{
+    protected $signature = 'verbs:replay';
+
+    protected $description = 'Replay all verbs events';
+
+    public function handle(): int
+    {
+        $models = $this->findModelsToTruncate();
+
+        $selected = multiselect(
+            label: 'Which models would you like to truncate?',
+            options: $models,
+            default: $models,
+            required: true
+        );
+
+        if (! $this->confirmModelTruncation($selected)) {
+            $this->error('Cancelling replay');
+
+            return Command::FAILURE;
+        }
+
+        $this->truncateSelectedModels($selected);
+
+        $this->info('Replaying Events');
+        Verbs::replay();
+
+        return Command::SUCCESS;
+    }
+
+    /** @return Collection<class-string, string> */
+    protected function findModelsToTruncate(): Collection
+    {
+        return ModelFinder::create()
+            ->withBasePaths(config('verbs.replay.base_directories'))
+            ->withRootNamespaces(config('verbs.replay.root_namespaces'))
+            ->withPaths(config('verbs.replay.paths'))
+            ->withBaseModels(config('verbs.replay.base_models'))
+            ->replayable()
+            ->mapWithKeys(fn ($fqcn) => [$fqcn => class_basename($fqcn)]);
+    }
+
+    /** @param  array<int, class-string>  $selected */
+    protected function confirmModelTruncation(array $selected): bool
+    {
+        return confirm(
+            label: sprintf('Are you sure you want to truncate the following %s before replaying events: %s',
+                count($selected) > 1 ? 'models' : 'model',
+                collect($selected)
+                    ->map(fn ($fqcn) => class_basename($fqcn))
+                    ->implode(', ')),
+            default: false,
+            hint: 'You must say yes to continue.'
+        );
+    }
+
+    /** @param  array<int, class-string>  $selected */
+    protected function truncateSelectedModels(array $selected): static
+    {
+        foreach ($selected as $model) {
+            $this->info("Truncating {$model}");
+
+            /** @var Model $model */
+            $model::truncate();
+        }
+
+        return $this;
+    }
+}

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -72,6 +72,10 @@ class Broker
                     ->each(fn ($state) => $this->dispatcher->apply($model->event(), $state))
                     ->each(fn ($state) => $this->dispatcher->replay($model->event(), $state));
 
+                if ($model->event()->states()->isEmpty()) {
+                    $this->dispatcher->replay($model->event());
+                }
+
                 return $model->event();
             });
 

--- a/src/Lifecycle/Dispatcher.php
+++ b/src/Lifecycle/Dispatcher.php
@@ -59,7 +59,7 @@ class Dispatcher
         $this->getHandleHooks($event)->each(fn (Hook $hook) => $hook->handle($this->container, $event));
     }
 
-    public function replay(Event $event, State $state): void
+    public function replay(Event $event, State $state = null): void
     {
         $this->getReplayHooks($event)->each(fn (Hook $hook) => $hook->replay($this->container, $event, $state));
     }

--- a/src/Support/ModelFinder.php
+++ b/src/Support/ModelFinder.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Thunk\Verbs\Support;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use ReflectionClass;
+use SplFileInfo;
+use Symfony\Component\Finder\Finder;
+use Thunk\Verbs\Attributes\Autodiscovery\Replayable;
+
+class ModelFinder
+{
+    /** @var string[] */
+    protected array $paths = [];
+
+    /** @var string[] */
+    protected array $baseModels = [];
+
+    /** @var string[] */
+    protected array $ignoredModels = [];
+
+    /** @var string[] */
+    protected array $basePaths;
+
+    /** @var string[] */
+    protected array $rootNamespaces = [''];
+
+    /** @var Collection<int, Model> */
+    protected Collection $models;
+
+    public function __construct()
+    {
+        $this->basePaths = [base_path()];
+    }
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function withPaths(array $paths): self
+    {
+        $this->paths = $paths;
+
+        return $this;
+    }
+
+    public function withBaseModels(array $baseModels): self
+    {
+        $this->baseModels = $baseModels;
+
+        return $this;
+    }
+
+    public function withBasePaths(array $basePaths): self
+    {
+        $this->basePaths = $basePaths;
+
+        return $this;
+    }
+
+    public function withRootNamespaces(array $rootNamespaces): self
+    {
+        $this->rootNamespaces = $rootNamespaces;
+
+        return $this;
+    }
+
+    public function replayable(): Collection
+    {
+        return $this->replayable ??= $this->all()
+            ->filter(function (ReflectionClass $class) {
+                $replayable = $class->getAttributes(Replayable::class);
+
+                if (count($replayable) === 0) {
+                    return false;
+                }
+
+                return data_get($replayable[0]->getArguments(), 'truncate', true);
+            })
+            ->map(fn (ReflectionClass $reflection) => $reflection->name)
+            ->values();
+    }
+
+    protected function all(): Collection
+    {
+        if (empty($this->paths)) {
+            return collect();
+        }
+
+        $files = (new Finder())->files()->in($this->paths);
+
+        $ignoredFiles = $this->getAutoloadedFiles(base_path('composer.json'));
+
+        $this->models = collect($files)
+            ->reject(fn (SplFileInfo $file) => in_array($file->getPathname(), $ignoredFiles))
+            ->map(fn (SplFileInfo $file) => $this->fullyQualifiedClassNameFromFile($file))
+            ->filter(fn (?string $modelClass) => $this->shouldClassBeIncluded($modelClass))
+            ->map(fn (string $modelClass) => new ReflectionClass($modelClass))
+            ->reject(fn (ReflectionClass $reflection) => $reflection->isAbstract());
+
+        return $this->models;
+    }
+
+    protected function getAutoloadedFiles($composerJsonPath): array
+    {
+        if (! file_exists($composerJsonPath)) {
+            return [];
+        }
+
+        $basePath = Str::before($composerJsonPath, 'composer.json');
+
+        $composerContents = json_decode(file_get_contents($composerJsonPath), true);
+
+        $paths = array_merge(
+            $composerContents['autoload']['files'] ?? [],
+            $composerContents['autoload-dev']['files'] ?? []
+        );
+
+        return array_map(fn (string $path) => realpath($basePath.$path), $paths);
+    }
+
+    protected function fullyQualifiedClassNameFromFile(SplFileInfo $file): ?string
+    {
+        $classes = collect($this->basePaths)
+            ->map(fn ($path) => trim(Str::replaceFirst($path, '', $file->getRealPath()), DIRECTORY_SEPARATOR))
+            ->map(fn ($class) => str_replace(
+                [DIRECTORY_SEPARATOR, 'App\\'],
+                ['\\', app()->getNamespace()],
+                ucfirst(Str::replaceLast('.php', '', $class))
+            ));
+
+        foreach ($this->rootNamespaces as $namespace) {
+            foreach ($classes as $class) {
+                $fqcn = $namespace.$class;
+
+                if (class_exists($fqcn)) {
+                    return $fqcn;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    protected function shouldClassBeIncluded(string $class = null): bool
+    {
+        if (in_array($class, $this->ignoredModels) || is_null($class)) {
+            return false;
+        }
+
+        foreach ($this->baseModels as $baseModelClass) {
+            if (is_subclass_of($class, $baseModelClass)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -8,6 +8,7 @@ use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Thunk\Verbs\Commands\MakeVerbEventCommand;
 use Thunk\Verbs\Commands\MakeVerbStateCommand;
+use Thunk\Verbs\Commands\ReplayEventsCommand;
 use Thunk\Verbs\Lifecycle\Broker;
 use Thunk\Verbs\Lifecycle\Dispatcher;
 use Thunk\Verbs\Lifecycle\EventStore;
@@ -28,6 +29,7 @@ class VerbsServiceProvider extends PackageServiceProvider
             ->hasCommands(
                 MakeVerbEventCommand::class,
                 MakeVerbStateCommand::class,
+                ReplayEventsCommand::class,
             )
             ->hasMigrations(
                 'create_verb_events_table',

--- a/tests/Feature/ReplayableTest.php
+++ b/tests/Feature/ReplayableTest.php
@@ -1,9 +1,19 @@
 <?php
 
+use Carbon\CarbonImmutable;
+use Glhd\Bits\Snowflake;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Thunk\Verbs\Event;
 use Thunk\Verbs\Examples\Bank\Models\Account;
 use Thunk\Verbs\Examples\Subscriptions\Models\Subscription;
+use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\Support\ModelFinder;
+use Thunk\Verbs\Tests\TestModels\Concert;
+use Thunk\Verbs\Tests\TestModels\Ticket;
+
+use function Pest\Laravel\artisan;
 
 it('finds all models that are replayable', function () {
     $models = ModelFinder::create()
@@ -25,3 +35,72 @@ it('finds all models that are replayable', function () {
             Subscription::class,
         ]);
 });
+
+it('truncates replayable models before replaying events', function () {
+    setUpTables();
+    config()->set('verbs.replay.base_directories', [realpath(__DIR__.'/../')]);
+    config()->set('verbs.replay.root_namespaces', ['Thunk\Verbs\Tests\\']);
+    config()->set('verbs.replay.paths', [realpath(__DIR__.'/../TestModels')]);
+
+    $user = Concert::create(['name' => 'VerbsCon']);
+
+    verb(new TicketPurchased(
+        account_id: Snowflake::make()->id(),
+        concert_id: $user->getKey(),
+    ));
+
+    verb(new TicketPurchased(
+        account_id: Snowflake::make()->id(),
+        concert_id: $user->getKey(),
+    ));
+
+    Verbs::commit();
+
+    expect(Concert::count())->toBe(1)
+        ->and(Ticket::count())->toBe(2);
+
+    artisan('verbs:replay')
+        ->expectsQuestion('Which models would you like to truncate?', [Ticket::class])
+        ->expectsQuestion('Are you sure you want to truncate the following model before replaying events: Ticket', true)
+        ->assertSuccessful();
+
+    expect(Concert::count())->toBe(1)
+        ->and(Ticket::count())->toBe(2);
+});
+
+function setUpTables()
+{
+    Schema::dropIfExists('concerts');
+    Schema::create('concerts', function (Blueprint $table) {
+        $table->id();
+        $table->string('name');
+        $table->timestamps();
+    });
+
+    Schema::dropIfExists('tickets');
+    Schema::create('tickets', function (Blueprint $table) {
+        $table->snowflakeId();
+        $table->foreignIdFor(Concert::class);
+        $table->timestamps();
+    });
+}
+
+class TicketPurchased extends Event
+{
+    public function __construct(
+        public string $account_id,
+        public int $concert_id,
+        public CarbonImmutable $created_at = new CarbonImmutable()
+    ) {
+    }
+
+    public function handle(): void
+    {
+        Ticket::create([
+            'id' => $this->account_id,
+            'concert_id' => $this->concert_id,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->created_at,
+        ]);
+    }
+}

--- a/tests/Feature/ReplayableTest.php
+++ b/tests/Feature/ReplayableTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+use Thunk\Verbs\Examples\Bank\Models\Account;
+use Thunk\Verbs\Examples\Subscriptions\Models\Subscription;
+use Thunk\Verbs\Support\ModelFinder;
+
+it('finds all models that are replayable', function () {
+    $models = ModelFinder::create()
+        ->withBasePaths([
+            realpath(__DIR__.'/../../examples/Bank/src'),
+            realpath(__DIR__.'/../../examples/Subscriptions/src'),
+        ])
+        ->withRootNamespaces([
+            'Thunk\Verbs\Examples\Bank\\',
+            'Thunk\Verbs\Examples\Subscriptions\\',
+        ])
+        ->withPaths([__DIR__.'/../../examples'])
+        ->withBaseModels([Model::class])
+        ->replayable();
+
+    expect($models)->toHaveCount(2)
+        ->toMatchArray([
+            Account::class,
+            Subscription::class,
+        ]);
+});

--- a/tests/TestModels/Concert.php
+++ b/tests/TestModels/Concert.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Thunk\Verbs\Tests\TestModels;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Concert extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/TestModels/Ticket.php
+++ b/tests/TestModels/Ticket.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Thunk\Verbs\Tests\TestModels;
+
+use Illuminate\Database\Eloquent\Model;
+use Thunk\Verbs\Attributes\Autodiscovery\Replayable;
+
+#[Replayable]
+class Ticket extends Model
+{
+    protected $guarded = [];
+}


### PR DESCRIPTION
This closes #16.

While it would be easy to have a simple `verbs:replay` command that just replays all of the events, an important step in the replay process is truncating models that are fully generated by events.

This PR adds a new `Attribute` called `Replayable` that can be added to any `Model` class. We then find all models with the `Replayable` attribute and before replaying events we will give the user a _Laravel Prompts_ multiselect option to choose which models they want truncated. They confirm their choice one last time before we truncate the models and then replay the events.

One thing to note is that I needed to update the replay functionality because it did not support replaying events that are not tied to a state.

The `ModelFinder` class was heavily inspired by the [Spatie `MorphMapGenerator` package](https://github.com/spatie/laravel-morph-map-generator/blob/main/src/DiscoverModels.php)

If this PR is accepted, I will add additional documentation.