### PR TITLE
Remove phases from events

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -9,7 +9,6 @@ use LogicException;
 use ReflectionMethod;
 use ReflectionParameter;
 use Thunk\Verbs\Exceptions\EventNotValidForCurrentState;
-use Thunk\Verbs\Lifecycle\Phase;
 use Thunk\Verbs\Support\EventSerializer;
 use Thunk\Verbs\Support\EventStateRegistry;
 use Thunk\Verbs\Support\PendingEvent;
@@ -67,7 +66,7 @@ abstract class Event
      * @param  class-string<T>|null  $state_type
      * @return T|null
      */
-    public function state(string $state_type = null): ?State
+    public function state(?string $state_type = null): ?State
     {
         $states = $this->states();
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -20,8 +20,6 @@ abstract class Event
 {
     public int $id;
 
-    public Phase $phase;
-
     /** @return PendingEvent<static> */
     public static function make(...$args): PendingEvent
     {
@@ -44,7 +42,7 @@ abstract class Event
 
         $event = app(EventSerializer::class)->deserialize(static::class, $args);
 
-        $event->id = Snowflake::make()->id();
+        $event->id ??= Snowflake::make()->id();
 
         return PendingEvent::make($event);
     }

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -26,9 +26,9 @@ class Broker
         $states = $event->states();
 
         $states->each(fn ($state) => Guards::for($event, $state)->check());
-		
+
         $states->each(fn ($state) => $this->dispatcher->apply($event, $state));
-		
+
         $this->dispatcher->fired($event, $states);
 
         app(Queue::class)->queue($event);

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -26,11 +26,9 @@ class Broker
         $states = $event->states();
 
         $states->each(fn ($state) => Guards::for($event, $state)->check());
-
-        $event->phase = Phase::Apply;
+		
         $states->each(fn ($state) => $this->dispatcher->apply($event, $state));
-
-        $event->phase = Phase::Fired;
+		
         $this->dispatcher->fired($event, $states);
 
         app(Queue::class)->queue($event);
@@ -51,7 +49,6 @@ class Broker
         }
 
         foreach ($events as $event) {
-            $event->phase = Phase::Handle;
             $this->dispatcher->handle($event);
         }
 

--- a/src/Lifecycle/EventStore.php
+++ b/src/Lifecycle/EventStore.php
@@ -22,9 +22,9 @@ use Thunk\Verbs\Support\EventSerializer;
 class EventStore
 {
     public function read(
-        State $state = null,
-        Bits|UuidInterface|AbstractUid|int|string $after_id = null,
-        Bits|UuidInterface|AbstractUid|int|string $up_to_id = null
+        ?State $state = null,
+        Bits|UuidInterface|AbstractUid|int|string|null $after_id = null,
+        Bits|UuidInterface|AbstractUid|int|string|null $up_to_id = null
     ): LazyCollection {
         if ($state) {
             return VerbStateEvent::query()

--- a/src/Lifecycle/Guards.php
+++ b/src/Lifecycle/Guards.php
@@ -11,7 +11,7 @@ use Thunk\Verbs\State;
 
 class Guards
 {
-    public static function for(Event $event, State $state = null): static
+    public static function for(Event $event, ?State $state = null): static
     {
         return new static($event, $state);
     }

--- a/src/Lifecycle/Guards.php
+++ b/src/Lifecycle/Guards.php
@@ -29,8 +29,6 @@ class Guards
 
     public function authorize(): static
     {
-        $this->event->phase = Phase::Authorize;
-
         if ($this->passesAuthorization()) {
             return $this;
         }
@@ -44,8 +42,6 @@ class Guards
 
     public function validate(): static
     {
-        $this->event->phase = Phase::Validate;
-
         $exception = new EventNotValidForCurrentState();
 
         try {

--- a/src/Lifecycle/Hook.php
+++ b/src/Lifecycle/Hook.php
@@ -98,21 +98,21 @@ class Hook
         }
     }
 
-    public function handle(Container $container, Event $event, State $state = null): void
+    public function handle(Container $container, Event $event, ?State $state = null): void
     {
         if ($this->runsInPhase(Phase::Handle)) {
             $container->call($this->callback, $this->guessParameters($event, $state));
         }
     }
 
-    public function replay(Container $container, Event $event, State $state = null): void
+    public function replay(Container $container, Event $event, ?State $state = null): void
     {
         if ($this->runsInPhase(Phase::Replay)) {
             $container->call($this->callback, $this->guessParameters($event, $state));
         }
     }
 
-    protected function guessParameters(Event $event, State $state = null, StateCollection $states = null): array
+    protected function guessParameters(Event $event, ?State $state = null, ?StateCollection $states = null): array
     {
         $parameters = [
             'e' => $event,

--- a/src/Models/VerbEvent.php
+++ b/src/Models/VerbEvent.php
@@ -24,7 +24,6 @@ class VerbEvent extends Model
     public function event(): Event
     {
         $this->event ??= app(EventSerializer::class)->deserialize($this->type, $this->data);
-        $this->event->phase = Phase::Replay;
 
         return $this->event;
     }

--- a/src/Models/VerbEvent.php
+++ b/src/Models/VerbEvent.php
@@ -5,7 +5,6 @@ namespace Thunk\Verbs\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Thunk\Verbs\Event;
-use Thunk\Verbs\Lifecycle\Phase;
 use Thunk\Verbs\State;
 use Thunk\Verbs\Support\EventSerializer;
 

--- a/src/Support/Normalization/BitsNormalizer.php
+++ b/src/Support/Normalization/BitsNormalizer.php
@@ -9,23 +9,23 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class BitsNormalizer implements DenormalizerInterface, NormalizerInterface
 {
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
     {
         return is_a($type, Bits::class, true);
     }
 
     /** @param  class-string<Bits>  $type */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): Bits
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): Bits
     {
         return $type::coerce($data);
     }
 
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null): bool
     {
         return $data instanceof Bits;
     }
 
-    public function normalize(mixed $object, string $format = null, array $context = []): string
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
     {
         if (! $object instanceof Bits) {
             throw new InvalidArgumentException(class_basename($this).' can only normalize Bits objects.');

--- a/src/Support/Normalization/CarbonNormalizer.php
+++ b/src/Support/Normalization/CarbonNormalizer.php
@@ -10,25 +10,25 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class CarbonNormalizer implements DenormalizerInterface, NormalizerInterface
 {
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
     {
         return is_a($type, CarbonInterface::class, true);
     }
 
     /** @param  class-string<CarbonInterface>  $type */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): CarbonInterface
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): CarbonInterface
     {
         return $type === CarbonInterface::class
             ? Date::parse($data)
             : $type::parse($data);
     }
 
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null): bool
     {
         return $data instanceof CarbonInterface;
     }
 
-    public function normalize(mixed $object, string $format = null, array $context = []): string
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
     {
         if (! $object instanceof CarbonInterface) {
             throw new InvalidArgumentException(class_basename($this).' can only normalize Carbon objects.');

--- a/src/Support/Normalization/CollectionNormalizer.php
+++ b/src/Support/Normalization/CollectionNormalizer.php
@@ -13,13 +13,13 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
 {
     use AcceptsNormalizerAndDenormalizer;
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
     {
         return is_a($type, Collection::class, true);
     }
 
     /** @param  class-string<Collection>  $type */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): Collection
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): Collection
     {
         $fqcn = data_get($data, 'fqcn', Collection::class);
         $items = data_get($data, 'items', []);
@@ -36,12 +36,12 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
         return $fqcn::make($items)->map(fn ($value) => $this->serializer->denormalize($value, $subtype, $format, $context));
     }
 
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null): bool
     {
         return $data instanceof Collection;
     }
 
-    public function normalize(mixed $object, string $format = null, array $context = []): array
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array
     {
         if (! $object instanceof Collection) {
             throw new InvalidArgumentException(class_basename($this).' can only normalize Collection objects.');

--- a/src/Support/Normalization/SelfSerializingNormalizer.php
+++ b/src/Support/Normalization/SelfSerializingNormalizer.php
@@ -12,13 +12,13 @@ class SelfSerializingNormalizer implements DenormalizerInterface, NormalizerInte
 {
     use AcceptsNormalizerAndDenormalizer;
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
     {
         return is_a($type, SerializedByVerbs::class, true);
     }
 
     /** @param  class-string<SerializedByVerbs>  $type */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): SerializedByVerbs
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): SerializedByVerbs
     {
         if (is_string($data)) {
             $data = json_decode($data, true);
@@ -27,12 +27,12 @@ class SelfSerializingNormalizer implements DenormalizerInterface, NormalizerInte
         return $type::deserializeForVerbs($data, $this->serializer);
     }
 
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null): bool
     {
         return $data instanceof SerializedByVerbs;
     }
 
-    public function normalize(mixed $object, string $format = null, array $context = []): array|string
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array|string
     {
         if (! $object instanceof SerializedByVerbs) {
             throw new InvalidArgumentException(class_basename($this).' can only normalize classes that implement SerializedByVerbs.');

--- a/src/Support/Normalization/StateNormalizer.php
+++ b/src/Support/Normalization/StateNormalizer.php
@@ -10,23 +10,23 @@ use Thunk\Verbs\State;
 
 class StateNormalizer implements DenormalizerInterface, NormalizerInterface
 {
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
     {
         return is_a($type, State::class, true) && is_numeric($data);
     }
 
     /** @param  class-string<State>  $type */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): State
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): State
     {
         return app(StateManager::class)->load((int) $data, $type);
     }
 
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null): bool
     {
         return $data instanceof State;
     }
 
-    public function normalize(mixed $object, string $format = null, array $context = []): string
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
     {
         if (! $object instanceof State) {
             throw new InvalidArgumentException(class_basename($this).' can only normalize State objects.');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -16,7 +16,7 @@ $examples = collect(Finder::create()->directories()->in(__DIR__.'/../examples/')
     ->values()
     ->all();
 
-expect()->extend('toThrow', function (string|Throwable $expected, string $message = null) {
+expect()->extend('toThrow', function (string|Throwable $expected, ?string $message = null) {
     if ($expected instanceof Throwable) {
         $message = $expected->getMessage();
         $expected = $expected::class;
@@ -38,7 +38,7 @@ expect()->extend('toThrow', function (string|Throwable $expected, string $messag
     return false;
 });
 
-expect()->extend('toBeMoney', function (Money|string|int $amount = null, string $currency = null) {
+expect()->extend('toBeMoney', function (Money|string|int|null $amount = null, ?string $currency = null) {
     $this->toBeInstanceOf(Money::class);
 
     if (isset($amount, $currency)) {


### PR DESCRIPTION
This should fix the `$phase` concern in #31 and help address the `$id` concern. We still think that events should have IDs, but I set it up so that it only sets the `$id` in make if it's not already set.