### PR TITLE
Prevent model serialization

### DIFF
--- a/config/verbs.php
+++ b/config/verbs.php
@@ -6,6 +6,7 @@ use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Thunk\Verbs\Support\Normalization\BitsNormalizer;
 use Thunk\Verbs\Support\Normalization\CarbonNormalizer;
 use Thunk\Verbs\Support\Normalization\CollectionNormalizer;
+use Thunk\Verbs\Support\Normalization\ModelNormalizer;
 use Thunk\Verbs\Support\Normalization\SelfSerializingNormalizer;
 use Thunk\Verbs\Support\Normalization\StateNormalizer;
 
@@ -41,6 +42,7 @@ return [
     'normalizers' => [
         SelfSerializingNormalizer::class,
         CollectionNormalizer::class,
+        ModelNormalizer::class,
         StateNormalizer::class,
         BitsNormalizer::class,
         CarbonNormalizer::class,

--- a/docs/state-vs-model.md
+++ b/docs/state-vs-model.md
@@ -12,3 +12,23 @@ state to have some overlapping properties.
 The important distinction is that, when you're using event sourcing, state is part of your event 
 system, and models are mostly for your application UI. It should always be possible to delete
 all the models that are created and updated via events, and rebuild them all by replaying your events.
+
+### Don't mix models and states
+
+In general, mixing Eloquent models with your event data can have unintended consequences,
+especially when it comes to replay. For example, imagine that you fire an event that creates
+a model, and then store that model's ID in a subsequent event. If you ever replay your events,
+the resulting model may have a different auto-incremented ID, and so your later event will
+unintentionally reference the wrong model.
+
+You can mitigate this issue by always using Snowflakes or ULIDs across your entire app, but
+it's still generally a bad idea. Because of this, Verbs will trigger an exception if you
+ever try to store a reference to a model inside your events or states.
+
+If you **really know what you're doing**, you can disable this behavior with:
+
+```php
+Thunk\Verbs\Support\Normalization\ModelNormalizer::dangerouslyAllowModelNormalization();
+```
+
+As the method name suggests, this is not recommended and may have unintended consequences. 

--- a/examples/Bank/tests/BankAccountTest.php
+++ b/examples/Bank/tests/BankAccountTest.php
@@ -22,19 +22,12 @@ test('a bank account can be opened and interacted with', function () {
 
     // First we'll open the account
 
-    $this->post(
-        route('bank.accounts.store'),
-        [
-            'initial_deposit_in_cents' => 1000_00,
-        ]
-    )->assertSuccessful();
+    $this->post(route('bank.accounts.store'), ['initial_deposit_in_cents' => 1000_00])
+        ->assertSuccessful();
 
-    expect(
-        $open_event = VerbEvent::type(AccountOpened::class)->whereDataContains([
-            'user_id' => User::first()->id,
-            'initial_deposit_in_cents' => 1000_00,
-        ])->first()
-    )->not->toBeNull();
+    $open_event = VerbEvent::type(AccountOpened::class)->sole();
+    expect($open_event->data['user_id'])->toBe(User::first()->id)
+        ->and($open_event->data['initial_deposit_in_cents'])->toBe(1000_00);
 
     $account = Auth::user()->accounts()->sole();
     expect($account->balance_in_cents)->toBe(1000_00);
@@ -43,62 +36,38 @@ test('a bank account can be opened and interacted with', function () {
 
     // Then we'll deposit some money
 
-    $this->post(
-        route('bank.accounts.deposits.store', $account),
-        [
-            'deposit_in_cents' => 499_99,
-        ]
-    )->assertSuccessful();
+    $this->post(route('bank.accounts.deposits.store', $account), ['deposit_in_cents' => 499_99])
+        ->assertSuccessful();
 
-    expect(
-        $deposit_event = VerbEvent::type(MoneyDeposited::class)->whereDataContains([
-            'account_id' => $account->id,
-            'cents' => 499_99,
-        ])->first()
-    )->not->toBeNull();
+    $deposit_event = VerbEvent::type(MoneyDeposited::class)->sole();
 
-    expect($account->refresh()->balance_in_cents)->toBe(1499_99);
+    expect($deposit_event->data['account_id'])->toBe($account->id)
+        ->and($deposit_event->data['cents'])->toBe(499_99)
+        ->and($account->refresh()->balance_in_cents)->toBe(1499_99);
 
     Mail::assertSent(fn (DepositAvailable $email) => $email->user_id === Auth::id());
 
     // Now we'll withdraw an amount that we have available to us
 
-    $this->post(
-        route('bank.accounts.withdrawals.store', $account),
-        [
-            'withdrawal_in_cents' => 1399_99,
-        ]
-    )
+    $this->post(route('bank.accounts.withdrawals.store', $account), ['withdrawal_in_cents' => 1399_99])
         ->assertSessionHasNoErrors()
         ->assertSuccessful();
 
-    expect(
-        $withdraw_event = VerbEvent::type(MoneyWithdrawn::class)->whereDataContains([
-            'account_id' => $account->id,
-            'cents' => 1399_99,
-        ])->first()
-    )->not->toBeNull();
+    $withdraw_event = VerbEvent::type(MoneyWithdrawn::class)->sole();
 
-    expect($account->refresh()->balance_in_cents)->toBe(100_00);
+    expect($withdraw_event->data['account_id'])->toBe($account->id)
+        ->and($withdraw_event->data['cents'])->toBe(1399_99)
+        ->and($account->refresh()->balance_in_cents)->toBe(100_00);
 
     // Next let's try to withdraw an amount that we don't have
 
-    // $this->withoutExceptionHandling();
+    $this->post(route('bank.accounts.withdrawals.store', $account), ['withdrawal_in_cents' => 100_01])
+        ->assertSessionHasErrors();
 
-    $this->post(
-        route('bank.accounts.withdrawals.store', $account),
-        [
-            'withdrawal_in_cents' => 100_01,
-        ]
-    )->assertSessionHasErrors();
+    expect(VerbEvent::type(MoneyWithdrawn::class)->count())->toBe(1)
+        ->and($account->refresh()->balance_in_cents)->toBe(100_00);
 
-    expect(
-        VerbEvent::type(MoneyWithdrawn::class)->count()
-    )->toBe(1);
-
-    expect($account->refresh()->balance_in_cents)->toBe(100_00);
-
-    // Lets assert the events are on the state store in the correct order
+    // Let's assert the events are on the state store in the correct order
 
     expect(AccountState::load($account->id)->storedEvents())
         ->toHaveCount(3)
@@ -119,8 +88,8 @@ test('a bank account can be opened and interacted with', function () {
     $account = Auth::user()->accounts()->sole();
     $account_state = AccountState::load($account->id);
 
-    expect($account->balance_in_cents)->toBe(100_00);
-    expect($account_state->balance_in_cents)->toBe(100_00);
+    expect($account->balance_in_cents)->toBe(100_00)
+        ->and($account_state->balance_in_cents)->toBe(100_00);
 
     Mail::assertNothingOutgoing();
 

--- a/examples/Monopoly/src/Support/MoneyNormalizer.php
+++ b/examples/Monopoly/src/Support/MoneyNormalizer.php
@@ -3,49 +3,42 @@
 namespace Thunk\Verbs\Examples\Monopoly\Support;
 
 use Brick\Money\Money;
-use Carbon\CarbonImmutable;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Date;
 use InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Thunk\Verbs\Examples\Monopoly\Game\Bank;
-use Thunk\Verbs\Examples\Monopoly\Game\Board;
-use Thunk\Verbs\Examples\Monopoly\Game\Phase;
-use Thunk\Verbs\State;
 
 class MoneyNormalizer implements DenormalizerInterface, NormalizerInterface
 {
-	public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
-	{
-		return is_a($type, Money::class, true);
-	}
-	
-	/** @param class-string<Money> $type */
-	public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): Money
-	{
-		return Money::ofMinor($data['amount'], $data['currency']);
-	}
-	
-	public function supportsNormalization(mixed $data, ?string $format = null): bool
-	{
-		return $data instanceof Money;
-	}
-	
-	public function normalize(mixed $object, ?string $format = null, array $context = []): array
-	{
-		if (! $object instanceof Money) {
-			throw new InvalidArgumentException(class_basename($this).' can only normalize Money objects.');
-		}
-		
-		return [
-			'amount' => (string) $object->getMinorAmount(), 
-			'currency' => $object->getCurrency()->getCurrencyCode()
-		];
-	}
-	
-	public function getSupportedTypes(?string $format): array
-	{
-		return [Money::class => false,];
-	}
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
+    {
+        return is_a($type, Money::class, true);
+    }
+
+    /** @param  class-string<Money>  $type */
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): Money
+    {
+        return Money::ofMinor($data['amount'], $data['currency']);
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    {
+        return $data instanceof Money;
+    }
+
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array
+    {
+        if (! $object instanceof Money) {
+            throw new InvalidArgumentException(class_basename($this).' can only normalize Money objects.');
+        }
+
+        return [
+            'amount' => (string) $object->getMinorAmount(),
+            'currency' => $object->getCurrency()->getCurrencyCode(),
+        ];
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Money::class => false];
+    }
 }

--- a/examples/Monopoly/src/Support/MoneyNormalizer.php
+++ b/examples/Monopoly/src/Support/MoneyNormalizer.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Thunk\Verbs\Examples\Monopoly\Support;
+
+use Brick\Money\Money;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
+use InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Thunk\Verbs\Examples\Monopoly\Game\Bank;
+use Thunk\Verbs\Examples\Monopoly\Game\Board;
+use Thunk\Verbs\Examples\Monopoly\Game\Phase;
+use Thunk\Verbs\State;
+
+class MoneyNormalizer implements DenormalizerInterface, NormalizerInterface
+{
+	public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
+	{
+		return is_a($type, Money::class, true);
+	}
+	
+	/** @param class-string<Money> $type */
+	public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): Money
+	{
+		return Money::ofMinor($data['amount'], $data['currency']);
+	}
+	
+	public function supportsNormalization(mixed $data, ?string $format = null): bool
+	{
+		return $data instanceof Money;
+	}
+	
+	public function normalize(mixed $object, ?string $format = null, array $context = []): array
+	{
+		if (! $object instanceof Money) {
+			throw new InvalidArgumentException(class_basename($this).' can only normalize Money objects.');
+		}
+		
+		return [
+			'amount' => (string) $object->getMinorAmount(), 
+			'currency' => $object->getCurrency()->getCurrencyCode()
+		];
+	}
+	
+	public function getSupportedTypes(?string $format): array
+	{
+		return [Money::class => false,];
+	}
+}

--- a/examples/Monopoly/tests/MonopolyTest.php
+++ b/examples/Monopoly/tests/MonopolyTest.php
@@ -20,9 +20,9 @@ use Thunk\Verbs\Exceptions\EventNotValidForCurrentState;
 use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\Models\VerbSnapshot;
 
-beforeEach(function() {
-	$normalizers = array_merge([MoneyNormalizer::class], config('verbs.normalizers'));
-	config()->set('verbs.normalizers', $normalizers);
+beforeEach(function () {
+    $normalizers = array_merge([MoneyNormalizer::class], config('verbs.normalizers'));
+    config()->set('verbs.normalizers', $normalizers);
 });
 
 it('can play a game of Monopoly', function () {

--- a/examples/Monopoly/tests/MonopolyTest.php
+++ b/examples/Monopoly/tests/MonopolyTest.php
@@ -15,9 +15,15 @@ use Thunk\Verbs\Examples\Monopoly\Game\Spaces\Properties\OrientalAvenue;
 use Thunk\Verbs\Examples\Monopoly\Game\Token;
 use Thunk\Verbs\Examples\Monopoly\States\GameState;
 use Thunk\Verbs\Examples\Monopoly\States\PlayerState;
+use Thunk\Verbs\Examples\Monopoly\Support\MoneyNormalizer;
 use Thunk\Verbs\Exceptions\EventNotValidForCurrentState;
 use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\Models\VerbSnapshot;
+
+beforeEach(function() {
+	$normalizers = array_merge([MoneyNormalizer::class], config('verbs.normalizers'));
+	config()->set('verbs.normalizers', $normalizers);
+});
 
 it('can play a game of Monopoly', function () {
 

--- a/src/Exceptions/DoNotStoreModelsOnEventsOrStates.php
+++ b/src/Exceptions/DoNotStoreModelsOnEventsOrStates.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Thunk\Verbs\Exceptions;
+
+use Illuminate\Contracts\Queue\QueueableCollection;
+use Illuminate\Contracts\Queue\QueueableEntity;
+use RuntimeException;
+
+class DoNotStoreModelsOnEventsOrStates extends RuntimeException
+{
+    public function __construct(QueueableEntity|QueueableCollection $object)
+    {
+        $type = class_basename($object);
+
+        // TODO: Write docs page and link to it
+
+        parent::__construct("You are trying to store a '{$type}' in your Verbs event data. This is probably not what you want to do!");
+    }
+}

--- a/src/Exceptions/DoNotStoreModelsOnEventsOrStates.php
+++ b/src/Exceptions/DoNotStoreModelsOnEventsOrStates.php
@@ -12,8 +12,8 @@ class DoNotStoreModelsOnEventsOrStates extends RuntimeException
     {
         $type = class_basename($object);
 
-        // TODO: Write docs page and link to it
+        $docs_url = 'https://verbs.thunk.dev/docs/crash-course/state-vs-model#content-dont-mix-models-and-states';
 
-        parent::__construct("You are trying to store a '{$type}' in your Verbs event data. This is probably not what you want to do!");
+        parent::__construct("You are trying to store a '{$type}' in your Verbs event data. This is probably not what you want to do! See: <{$docs_url}>");
     }
 }

--- a/src/Models/VerbEvent.php
+++ b/src/Models/VerbEvent.php
@@ -54,17 +54,6 @@ class VerbEvent extends Model
         return $query->where('type', $type);
     }
 
-    public function scopeWhereDataContains($query, $data)
-    {
-        $data = Arr::wrap($data);
-
-        return $query->where(function ($query) use ($data) {
-            foreach ($data as $value) {
-                $query->whereJsonContains('data', $value);
-            }
-        });
-    }
-
     public function getIncrementing()
     {
         return false;

--- a/src/Models/VerbEvent.php
+++ b/src/Models/VerbEvent.php
@@ -4,7 +4,6 @@ namespace Thunk\Verbs\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Support\Arr;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Metadata;
 use Thunk\Verbs\State;

--- a/src/Models/VerbEvent.php
+++ b/src/Models/VerbEvent.php
@@ -4,6 +4,7 @@ namespace Thunk\Verbs\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Arr;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Metadata;
 use Thunk\Verbs\State;
@@ -53,9 +54,15 @@ class VerbEvent extends Model
         return $query->where('type', $type);
     }
 
-    public function scopeWhereDataContains($query, array $data)
+    public function scopeWhereDataContains($query, $data)
     {
-        return $query->whereJsonContains('data', $data);
+        $data = Arr::wrap($data);
+
+        return $query->where(function($query) use ($data) {
+            foreach ($data as $value) {
+                $query->whereJsonContains('data', $value);
+            }
+        });
     }
 
     public function getIncrementing()

--- a/src/Models/VerbSnapshot.php
+++ b/src/Models/VerbSnapshot.php
@@ -37,11 +37,6 @@ class VerbSnapshot extends Model
         return $query->where('type', $type);
     }
 
-    public function scopeWhereDataContains($query, array $data)
-    {
-        return $query->whereJsonContains('data', $data);
-    }
-
     public function getKeyType()
     {
         $id_type = strtolower(config('verbs.id_type', 'snowflake'));

--- a/src/Support/Normalization/ModelNormalizer.php
+++ b/src/Support/Normalization/ModelNormalizer.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Thunk\Verbs\Support\Normalization;
+
+use Illuminate\Contracts\Database\ModelIdentifier;
+use Illuminate\Contracts\Queue\QueueableCollection;
+use Illuminate\Contracts\Queue\QueueableEntity;
+use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
+use InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Thunk\Verbs\Exceptions\DoNotStoreModelsOnEventsOrStates;
+
+class ModelNormalizer implements DenormalizerInterface, NormalizerInterface
+{
+    use SerializesAndRestoresModelIdentifiers;
+
+    protected static $allow_normalization = false;
+
+    public static function dangerouslyAllowModelNormalization(bool $allow_normalization = true): void
+    {
+        static::$allow_normalization = $allow_normalization;
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
+    {
+        return $this->typeSupportsModelIdentifiers($type) && $this->isDenormalizedModelIdentifier($data);
+    }
+
+    /** @param  class-string<QueueableEntity|QueueableCollection>  $type */
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): QueueableEntity|QueueableCollection
+    {
+        if (is_array($data)) {
+            $data = new ModelIdentifier($data['class'], $data['id'], $data['relations'], $data['connection']);
+
+            if (isset($data['collectionClass'])) {
+                $data->useCollectionClass($data['collectionClass']);
+            }
+        }
+
+        return $this->getRestoredPropertyValue($data);
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    {
+        return $data instanceof QueueableEntity
+            || $data instanceof QueueableCollection;
+    }
+
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array
+    {
+        if (! $this->supportsNormalization($object)) {
+            throw new InvalidArgumentException(class_basename($this).' can only normalize queueable entities or collections.');
+        }
+
+        if (static::$allow_normalization) {
+            return (array) $this->getSerializedPropertyValue($object);
+        }
+
+        throw new DoNotStoreModelsOnEventsOrStates($object);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            QueueableEntity::class => false,
+            QueueableCollection::class => false,
+        ];
+    }
+
+    protected function typeSupportsModelIdentifiers(string $type): bool
+    {
+        return is_a($type, QueueableEntity::class, true)
+        || is_a($type, QueueableCollection::class, true);
+    }
+
+    protected function isDenormalizedModelIdentifier($denormalized): bool
+    {
+        return $denormalized instanceof ModelIdentifier
+            || isset($denormalized['class'], $denormalized['id'], $denormalized['relations'], $denormalized['connection']);
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,7 @@
 
 use Brick\Money\Money;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Grammars\SQLiteGrammar;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -52,8 +53,10 @@ expect()->extend('toBeMoney', function (Money|string|int|null $amount = null, ?s
 });
 
 uses(TestCase::class)
-    ->beforeEach(fn () => match (DB::connection()->getDriverName()) {
-        'sqlite' => DB::connection()->setQueryGrammar(new PatchedSQLiteGrammar()),
-        default => null,
-    })
+	->beforeEach(function() {
+		$db = DB::connection();
+		if ($db->getQueryGrammar() instanceof SQLiteGrammar) {
+			$db->setQueryGrammar(new PatchedSQLiteGrammar());	
+		}
+	})
     ->in(__DIR__, ...$examples);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,6 +3,7 @@
 use Brick\Money\Money;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Grammars\SQLiteGrammar;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -55,7 +56,10 @@ expect()->extend('toBeMoney', function (Money|string|int|null $amount = null, ?s
 uses(TestCase::class)
     ->beforeEach(function () {
         $db = DB::connection();
-        if ($db->getQueryGrammar() instanceof SQLiteGrammar) {
+        if (
+            version_compare(App::version(), '10.38.0', '<')
+            && $db->getQueryGrammar() instanceof SQLiteGrammar
+        ) {
             $db->setQueryGrammar(new PatchedSQLiteGrammar());
         }
     })

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -53,10 +53,10 @@ expect()->extend('toBeMoney', function (Money|string|int|null $amount = null, ?s
 });
 
 uses(TestCase::class)
-	->beforeEach(function() {
-		$db = DB::connection();
-		if ($db->getQueryGrammar() instanceof SQLiteGrammar) {
-			$db->setQueryGrammar(new PatchedSQLiteGrammar());	
-		}
-	})
+    ->beforeEach(function () {
+        $db = DB::connection();
+        if ($db->getQueryGrammar() instanceof SQLiteGrammar) {
+            $db->setQueryGrammar(new PatchedSQLiteGrammar());
+        }
+    })
     ->in(__DIR__, ...$examples);

--- a/tests/Support/PatchedSQLiteGrammar.php
+++ b/tests/Support/PatchedSQLiteGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Thunk\Verbs\Tests\Support;
 
+use Illuminate\Database\Concerns\CompilesJsonPaths;
 use Illuminate\Database\Query\Grammars\SQLiteGrammar;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -13,6 +14,8 @@ use Illuminate\Support\Facades\DB;
 
 class PatchedSQLiteGrammar extends SQLiteGrammar
 {
+    use CompilesJsonPaths;
+
     public function __construct()
     {
         DB::connection()

--- a/tests/Support/PatchedSQLiteGrammar.php
+++ b/tests/Support/PatchedSQLiteGrammar.php
@@ -2,54 +2,22 @@
 
 namespace Thunk\Verbs\Tests\Support;
 
-use Illuminate\Database\Concerns\CompilesJsonPaths;
 use Illuminate\Database\Query\Grammars\SQLiteGrammar;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 
-// Stolen from: @joecampo
-// Original Laracasts Answer: https://laracasts.com/discuss/channels/laravel/wherejsoncontains-equivalent-for-sqlite-database?page=1&replyId=894087
-// Modified slightly to not use strict mode
-// Modified to use collection diff
+// This just brings in the 10.38.0 code:
+// https://github.com/laravel/framework/pull/49401
 
 class PatchedSQLiteGrammar extends SQLiteGrammar
 {
-    use CompilesJsonPaths;
-
-    public function __construct()
-    {
-        DB::connection()
-            ->getPdo()
-            ->sqliteCreateFunction(
-                'JSON_CONTAINS',
-                function ($json, $val, $path = null) {
-                    $decoded_needle = collect(json_decode(trim($val, '"'), true, 512, JSON_THROW_ON_ERROR));
-                    $decoded_haystack = collect(json_decode($json, true, 512, JSON_THROW_ON_ERROR));
-
-                    if ($path) {
-                        return $this->collectionContainsCollection(
-                            $decoded_needle,
-                            $decoded_haystack->pluck($path)
-                        );
-                    }
-
-                    return $this->collectionContainsCollection(
-                        $decoded_needle,
-                        $decoded_haystack
-                    );
-                }
-            );
-    }
-
     protected function compileJsonContains($column, $value)
     {
         [$field, $path] = $this->wrapJsonFieldAndPath($column);
 
-        return 'json_contains('.$field.', '.$value.$path.')';
+        return 'exists (select 1 from json_each(' . $field . $path . ') where ' . $this->wrap('json_each.value') . ' is ' . $value . ')';
     }
 
-    protected function collectionContainsCollection(Collection $needle, Collection $haystack): bool
+    public function prepareBindingForJsonContains($binding)
     {
-        return $needle->intersect($haystack)->count() == $needle->count();
+        return $binding;
     }
 }

--- a/tests/Support/PatchedSQLiteGrammar.php
+++ b/tests/Support/PatchedSQLiteGrammar.php
@@ -13,7 +13,7 @@ class PatchedSQLiteGrammar extends SQLiteGrammar
     {
         [$field, $path] = $this->wrapJsonFieldAndPath($column);
 
-        return 'exists (select 1 from json_each(' . $field . $path . ') where ' . $this->wrap('json_each.value') . ' is ' . $value . ')';
+        return 'exists (select 1 from json_each('.$field.$path.') where '.$this->wrap('json_each.value').' is '.$value.')';
     }
 
     public function prepareBindingForJsonContains($binding)

--- a/tests/Unit/ModelNormalizerTest.php
+++ b/tests/Unit/ModelNormalizerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Serializer as SymfonySerializer;
+use Thunk\Verbs\Exceptions\DoNotStoreModelsOnEventsOrStates;
+use Thunk\Verbs\Support\Normalization\ModelNormalizer;
+
+it('throws an exception when trying to serialize a model', function () {
+    $serializer = new SymfonySerializer(
+        normalizers: [$normalizer = new ModelNormalizer()],
+        encoders: [new JsonEncoder()],
+    );
+
+    $serializer->normalize(new class() extends Model
+    {
+    }, 'json');
+})->throws(DoNotStoreModelsOnEventsOrStates::class);

--- a/tests/Unit/ModelNormalizerTest.php
+++ b/tests/Unit/ModelNormalizerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Contracts\Database\ModelIdentifier;
+use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Database\Eloquent\Model;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Serializer as SymfonySerializer;
@@ -8,11 +10,91 @@ use Thunk\Verbs\Support\Normalization\ModelNormalizer;
 
 it('throws an exception when trying to serialize a model', function () {
     $serializer = new SymfonySerializer(
+        normalizers: [new ModelNormalizer()],
+        encoders: [new JsonEncoder()],
+    );
+
+    $serializer->normalize(new ModelNormalizerTestModel(), 'json');
+})->throws(DoNotStoreModelsOnEventsOrStates::class);
+
+it('denormalizes models', function () {
+    $serializer = new SymfonySerializer(
         normalizers: [$normalizer = new ModelNormalizer()],
         encoders: [new JsonEncoder()],
     );
 
-    $serializer->normalize(new class() extends Model
+    $identifier = new ModelIdentifier(
+        class: ModelNormalizerTestModel::class,
+        id: 1,
+        relations: [],
+        connection: null,
+    );
+
+    $identifier_array = [
+        'class' => ModelNormalizerTestModel::class,
+        'id' => 1,
+    ];
+
+    expect($normalizer->supportsDenormalization($identifier, ModelNormalizerTestModel::class))->toBeTrue()
+        ->and($normalizer->supportsDenormalization($identifier_array, ModelNormalizerTestModel::class))->toBeTrue();
+
+    $result = $serializer->denormalize($identifier, ModelNormalizerTestModel::class, 'json');
+
+    expect($result->source)->toBe(ModelNormalizerTestModel::class);
+
+    $result = $serializer->denormalize($identifier_array, ModelNormalizerTestModel::class, 'json');
+
+    expect($result->source)->toBe(ModelNormalizerTestModel::class);
+});
+
+it('normalizes models when forced to do so', function () {
+    $serializer = new SymfonySerializer(
+        normalizers: [$normalizer = new ModelNormalizer()],
+        encoders: [new JsonEncoder()],
+    );
+
+    ModelNormalizer::dangerouslyAllowModelNormalization();
+
+    $model = new ModelNormalizerTestModel(['id' => 1337]);
+
+    expect($normalizer->supportsNormalization($model))->toBeTrue();
+
+    $normalized = $serializer->normalize($model, 'json');
+
+    expect($normalized)->toMatchArray([
+        'class' => ModelNormalizerTestModel::class,
+        'id' => 1337,
+    ]);
+
+    $serialized = $serializer->serialize($model, 'json');
+
+    expect($serialized)->toBe('{"class":"ModelNormalizerTestModel","id":1337}');
+});
+
+class ModelNormalizerTestModel extends Model
+{
+    public function newQueryForRestoration($ids)
     {
-    }, 'json');
-})->throws(DoNotStoreModelsOnEventsOrStates::class);
+        return new class implements QueueableEntity
+        {
+            public string $source = ModelNormalizerTestModel::class;
+
+            public function __call(string $name, array $arguments)
+            {
+                return $this;
+            }
+
+            public function getQueueableId()
+            {
+            }
+
+            public function getQueueableRelations()
+            {
+            }
+
+            public function getQueueableConnection()
+            {
+            }
+        };
+    }
+}


### PR DESCRIPTION
This adds a new normalizer that essentially prevents storing Eloquent models or collections on Verbs states or events. If we merge this, it also needs a page in the docs explaining why this isn't a good idea.

It also includes a `ModelNormalizer::dangerouslyAllowModelNormalization()` escape hatch for folks who want to do terrible terrible things :)