### PR TITLE
Fix auto-discovery exception messages

### DIFF
--- a/src/Attributes/Autodiscovery/AppliesToSingletonState.php
+++ b/src/Attributes/Autodiscovery/AppliesToSingletonState.php
@@ -16,7 +16,7 @@ class AppliesToSingletonState extends StateDiscoveryAttribute
         public ?string $alias = null,
     ) {
         if (! is_a($this->state_type, State::class, true)) {
-            throw new InvalidArgumentException('You must pass state class names to the "AppliesToState" attribute.');
+            throw new InvalidArgumentException('You must pass state class names to the "AppliesToSingletonState" attribute.');
         }
     }
 

--- a/src/Attributes/Autodiscovery/StateId.php
+++ b/src/Attributes/Autodiscovery/StateId.php
@@ -18,7 +18,7 @@ class StateId extends StateDiscoveryAttribute
         public bool $autofill = true,
     ) {
         if (! is_a($this->state_type, State::class, true)) {
-            throw new InvalidArgumentException('You must pass state class names to the "Identifies" attribute.');
+            throw new InvalidArgumentException('You must pass state class names to the "StateId" attribute.');
         }
     }
 


### PR DESCRIPTION
I figured this is what was intended for the exception messages based on the messages in the other attributes.