### PR TITLE
Add isAllowed() and isValid() methods for PendingEvent

### DIFF
--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -3,11 +3,14 @@
 namespace Thunk\Verbs\Lifecycle;
 
 use Glhd\Bits\Bits;
-use Ramsey\Uuid\UuidInterface;
-use Symfony\Component\Uid\AbstractUid;
-use Thunk\Verbs\CommitsImmediately;
 use Thunk\Verbs\Event;
+use Ramsey\Uuid\UuidInterface;
+use Thunk\Verbs\CommitsImmediately;
+use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Lifecycle\Queue as EventQueue;
+use Illuminate\Auth\Access\AuthorizationException;
+use Throwable;
+use Thunk\Verbs\Exceptions\EventNotValidForCurrentState;
 
 class Broker
 {
@@ -33,6 +36,8 @@ class Broker
         $states = $event->states();
 
         $states->each(fn ($state) => Guards::for($event, $state)->check());
+
+        Guards::for($event, null)->check();
 
         $states->each(fn ($state) => $this->dispatcher->apply($event, $state));
 
@@ -64,6 +69,34 @@ class Broker
         }
 
         return $this->commit();
+    }
+
+    public function isValid(Event $event): bool
+    {
+        try {
+            $states = $event->states();
+
+            Guards::for($event, null)->validate();
+            $states->each(fn ($state) => Guards::for($event, $state)->validate());
+
+            return true;
+        } catch (EventNotValidForCurrentState $e) {
+            return false;
+        }
+    }
+
+    public function isAllowed(Event $event): bool
+    {
+        try {
+            $states = $event->states();
+
+            Guards::for($event, null)->authorize();
+            $states->each(fn ($state) => Guards::for($event, $state)->authorize());
+
+            return true;
+        } catch (Throwable $e) {
+            return false;
+        }
     }
 
     public function replay(?callable $beforeEach = null, ?callable $afterEach = null)

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -3,14 +3,13 @@
 namespace Thunk\Verbs\Lifecycle;
 
 use Glhd\Bits\Bits;
-use Thunk\Verbs\Event;
 use Ramsey\Uuid\UuidInterface;
-use Thunk\Verbs\CommitsImmediately;
 use Symfony\Component\Uid\AbstractUid;
-use Thunk\Verbs\Lifecycle\Queue as EventQueue;
-use Illuminate\Auth\Access\AuthorizationException;
 use Throwable;
+use Thunk\Verbs\CommitsImmediately;
+use Thunk\Verbs\Event;
 use Thunk\Verbs\Exceptions\EventNotValidForCurrentState;
+use Thunk\Verbs\Lifecycle\Queue as EventQueue;
 
 class Broker
 {

--- a/src/Lifecycle/Dispatcher.php
+++ b/src/Lifecycle/Dispatcher.php
@@ -33,7 +33,7 @@ class Dispatcher
         }
     }
 
-    public function validate(Event $event, State $state): bool
+    public function validate(Event $event, ?State $state = null): bool
     {
         foreach ($this->getValidationHooks($event, $state) as $hook) {
             if (! $hook->validate($this->container, $event, $state)) {
@@ -107,16 +107,18 @@ class Dispatcher
     }
 
     /** @return Collection<int, Hook> */
-    protected function getValidationHooks(Event $event, State $state): Collection
+    protected function getValidationHooks(Event $event, ?State $state = null): Collection
     {
         $hooks = collect($this->hooks[$event::class] ?? []);
 
-        $validation_hooks = MethodFinder::for($event)
-            ->prefixed('validate')
-            ->expecting($state::class)
-            ->map(fn (ReflectionMethod $name) => Hook::fromClassMethod($event, $name)->forcePhases(Phase::Validate));
-
-        // FIXME: We need to handle special `validate()` hook with no suffix
+        $validation_hooks = $state === null
+            ? MethodFinder::for($event)
+                ->prefixed('validate')
+                ->map(fn (ReflectionMethod $name) => Hook::fromClassMethod($event, $name)->forcePhases(Phase::Validate))
+            : MethodFinder::for($event)
+                ->prefixed('validate')
+                ->expecting($state::class)
+                ->map(fn (ReflectionMethod $name) => Hook::fromClassMethod($event, $name)->forcePhases(Phase::Validate));
 
         return $hooks
             ->merge($validation_hooks)

--- a/src/Lifecycle/Guards.php
+++ b/src/Lifecycle/Guards.php
@@ -64,9 +64,15 @@ class Guards
         if (method_exists($this->event, 'authorize')) {
             $result = app()->call([$this->event, 'authorize']);
 
-            return $result instanceof Response
-                ? $result->authorize()
-                : $result;
+            if ($result instanceof Response) {
+                return $result->authorize();
+            }
+
+            if ($result instanceof bool) {
+                return $result;
+            }
+
+            return true;
         }
 
         return true;

--- a/src/Lifecycle/Hook.php
+++ b/src/Lifecycle/Hook.php
@@ -75,7 +75,7 @@ class Hook
         return isset($this->phases[$phase]) && $this->phases[$phase] === true;
     }
 
-    public function validate(Container $container, Event $event, State $state): bool
+    public function validate(Container $container, Event $event, ?State $state = null): bool
     {
         if ($this->runsInPhase(Phase::Validate)) {
             return $container->call($this->callback, $this->guessParameters($event, $state)) ?? true;

--- a/src/Support/MethodFinder.php
+++ b/src/Support/MethodFinder.php
@@ -66,7 +66,7 @@ class MethodFinder
 
     protected function expectsParameters(ReflectionMethod $method): bool
     {
-        if (count($this->types) === 0) {
+        if ($this->types && count($this->types) === 0) {
             return true;
         }
 
@@ -80,8 +80,7 @@ class MethodFinder
                 return true;
             }
 
-            $interface_matches = $this
-                ->types
+            $interface_matches = ($this->types ?? collect())
                 ->map(fn ($type) => class_implements($type))
                 ->flatten()
                 ->unique()

--- a/src/Support/PendingEvent.php
+++ b/src/Support/PendingEvent.php
@@ -121,6 +121,16 @@ class PendingEvent
         return $results->count() > 1 ? $results : $results->first();
     }
 
+    public function isAllowed(): bool
+    {
+        return app(Broker::class)->isAllowed($this->event);
+    }
+
+    public function isValid(): bool
+    {
+        return app(Broker::class)->isValid($this->event);
+    }
+
     /** @param  callable(Throwable): Throwable  $handler */
     public function onError(Closure $handler): static
     {

--- a/tests/Feature/PendingEventChecksTest.php
+++ b/tests/Feature/PendingEventChecksTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use Thunk\Verbs\Event;
+use Thunk\Verbs\State;
+use Glhd\Bits\Snowflake;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Str;
+use Thunk\Verbs\SerializedByVerbs;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Support\Normalization\NormalizeToPropertiesAndClassName;
+
+it('can test authorization on a pending event', function () {
+    $event = EventWithMultipleStates::make([
+        'special_id' => 1,
+        'other_id' => 2,
+        'allowed' => true,
+    ]);
+
+    $this->assertTrue($event->isAllowed());
+
+    $event = EventWithMultipleStates::make([
+        'special_id' => 1,
+        'other_id' => 2,
+        'allowed' => false,
+    ]);
+
+    $this->assertFalse($event->isAllowed());
+});
+
+it('can test validation on a pending event', function () {
+    SpecialState::factory()->create([
+        'name' => 'daniel',
+    ], 1);
+
+    OtherState::factory()->create([
+        'name' => 'jacob',
+    ], 2);
+
+    OtherState::factory()->create([
+        'name' => 'bad bad bad',
+    ], 3);
+
+    $event = EventWithMultipleStates::make([
+        'special_id' => 1,
+        'other_id' => 2,
+        'allowed' => true,
+    ]);
+
+    $this->assertTrue($event->isValid());
+
+    $event = EventWithMultipleStates::make([
+        'special_id' => 1,
+        'other_id' => 2,
+        'allowed' => false,
+    ]);
+
+    $this->assertFalse($event->isValid());
+
+    $event = EventWithMultipleStates::make([
+        'special_id' => 1,
+        'other_id' => 3,
+        'allowed' => true,
+    ]);
+
+    $this->assertFalse($event->isValid());
+});
+
+
+class EventWithMultipleStates extends Event
+{
+    #[StateId(SpecialState::class)]
+    public int $special_id;
+
+    #[StateId(OtherState::class)]
+    public int $other_id;
+
+    public bool $allowed;
+
+    public function authorize()
+    {
+        $this->assert(
+            $this->allowed === true,
+            'You are not allowed to do that.',
+        );
+    }
+
+    public function validate() {
+        $this->assert(
+            $this->allowed === true,
+            'Allowed has to be true.'
+        );
+    }
+
+    public function validateSpecialState(SpecialState $state)
+    {
+        $this->assert(
+            $state->name === 'daniel',
+            'Special state name must be daniel.',
+        );
+    }
+
+    public function validateOtherState(OtherState $state)
+    {
+        $this->assert(
+            $state->name === 'jacob',
+            'Other state name must be jacob.',
+        );
+    }
+}
+
+class SpecialState extends State
+{
+    public string $name;
+}
+
+class OtherState extends State
+{
+    public string $name;
+}

--- a/tests/Feature/PendingEventChecksTest.php
+++ b/tests/Feature/PendingEventChecksTest.php
@@ -1,13 +1,8 @@
 <?php
 
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\State;
-use Glhd\Bits\Snowflake;
-use Carbon\CarbonInterface;
-use Illuminate\Support\Str;
-use Thunk\Verbs\SerializedByVerbs;
-use Thunk\Verbs\Attributes\Autodiscovery\StateId;
-use Thunk\Verbs\Support\Normalization\NormalizeToPropertiesAndClassName;
 
 it('can test authorization on a pending event', function () {
     $event = EventWithMultipleStates::make([
@@ -65,7 +60,6 @@ it('can test validation on a pending event', function () {
     $this->assertFalse($event->isValid());
 });
 
-
 class EventWithMultipleStates extends Event
 {
     #[StateId(SpecialState::class)]
@@ -84,7 +78,8 @@ class EventWithMultipleStates extends Event
         );
     }
 
-    public function validate() {
+    public function validate()
+    {
         $this->assert(
             $this->allowed === true,
             'Allowed has to be true.'


### PR DESCRIPTION
This lets us check whether an event is valid/authorized without firing it.

My use case is: compiling a list of available actions by filtering a master list by `$e->isAllowed()` and `$e->isValid()`

This PR also includes two changes to existing behavior:

1. Stateless `validate()` methods. You can now write a validate method that does not accept a state.
2. `authorize()` methods do not need to return a boolean, returning null is fine (allows us to use `$this->assert` like we do in validate methods)