### PR TITLE
Fix the mysql json order bug

### DIFF
--- a/src/Support/Normalization/CollectionNormalizer.php
+++ b/src/Support/Normalization/CollectionNormalizer.php
@@ -57,7 +57,7 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
             'items' => Arr::isAssoc($object->all())
                 ? $object->map(fn ($value, $key) => [$key, $this->serializer->normalize($value, $format, $context)])->values()->all()
                 : $object->map(fn ($value) => $this->serializer->normalize($value, $format, $context))->values()->all(),
-            'assoc' => Arr::isAssoc($object->all())
+            'assoc' => Arr::isAssoc($object->all()),
         ]);
     }
 

--- a/src/Support/Normalization/CollectionNormalizer.php
+++ b/src/Support/Normalization/CollectionNormalizer.php
@@ -24,7 +24,7 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
     {
         $fqcn = data_get($data, 'fqcn', Collection::class);
         $items = data_get($data, 'items', []);
-        $isAssoc = data_get($data, 'assoc', false);
+        $isAssoc = data_get($data, 'associative', false);
 
         if ($items === []) {
             return new $fqcn();
@@ -57,7 +57,7 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
             'items' => Arr::isAssoc($object->all())
                 ? $object->map(fn ($value, $key) => [$key, $this->serializer->normalize($value, $format, $context)])->values()->all()
                 : $object->map(fn ($value) => $this->serializer->normalize($value, $format, $context))->values()->all(),
-            'assoc' => Arr::isAssoc($object->all()),
+            'associative' => Arr::isAssoc($object->all())
         ]);
     }
 

--- a/src/Support/Normalization/CollectionNormalizer.php
+++ b/src/Support/Normalization/CollectionNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Thunk\Verbs\Support\Normalization;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -23,6 +24,7 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
     {
         $fqcn = data_get($data, 'fqcn', Collection::class);
         $items = data_get($data, 'items', []);
+        $isAssoc = data_get($data, 'assoc', false);
 
         if ($items === []) {
             return new $fqcn();
@@ -33,11 +35,9 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
             throw new InvalidArgumentException('Cannot denormalize a Collection that has no type information.');
         }
 
-        return $fqcn::make($items)->mapWithKeys(
-            fn ($value) => [
-                $value[0] => $this->serializer->denormalize($value[1], $subtype, $format, $context),
-            ]
-        );
+        return $fqcn::make($items)
+            ->when($isAssoc, fn ($collection) => $collection->mapWithKeys(fn ($value) => [$value[0] => $value[1]]))
+            ->map(fn ($value) => $this->serializer->denormalize($value, $subtype, $format, $context));
     }
 
     public function supportsNormalization(mixed $data, ?string $format = null): bool
@@ -54,7 +54,10 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
         return array_filter([
             'fqcn' => $object::class === Collection::class ? null : $object::class,
             'type' => $this->determineContainedType($object),
-            'items' => $object->map(fn ($value, $key) => [$key, $this->serializer->normalize($value, $format, $context)])->values()->all(),
+            'items' => Arr::isAssoc($object->all())
+                ? $object->map(fn ($value, $key) => [$key, $this->serializer->normalize($value, $format, $context)])->values()->all()
+                : $object->map(fn ($value) => $this->serializer->normalize($value, $format, $context))->values()->all(),
+            'assoc' => Arr::isAssoc($object->all())
         ]);
     }
 

--- a/src/Support/Normalization/CollectionNormalizer.php
+++ b/src/Support/Normalization/CollectionNormalizer.php
@@ -33,7 +33,11 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
             throw new InvalidArgumentException('Cannot denormalize a Collection that has no type information.');
         }
 
-        return $fqcn::make($items)->map(fn ($value) => $this->serializer->denormalize($value, $subtype, $format, $context));
+        return $fqcn::make($items)->mapWithKeys(
+            fn ($value) => [
+                $value[0] => $this->serializer->denormalize($value[1], $subtype, $format, $context)
+            ]
+        );
     }
 
     public function supportsNormalization(mixed $data, ?string $format = null): bool
@@ -50,7 +54,7 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
         return array_filter([
             'fqcn' => $object::class === Collection::class ? null : $object::class,
             'type' => $this->determineContainedType($object),
-            'items' => $object->map(fn ($value) => $this->serializer->normalize($value, $format, $context))->all(),
+            'items' => $object->map(fn ($value, $key) => [$key, $this->serializer->normalize($value, $format, $context)])->values()->all(),
         ]);
     }
 

--- a/src/Support/Normalization/CollectionNormalizer.php
+++ b/src/Support/Normalization/CollectionNormalizer.php
@@ -57,7 +57,7 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
             'items' => Arr::isAssoc($object->all())
                 ? $object->map(fn ($value, $key) => [$key, $this->serializer->normalize($value, $format, $context)])->values()->all()
                 : $object->map(fn ($value) => $this->serializer->normalize($value, $format, $context))->values()->all(),
-            'associative' => Arr::isAssoc($object->all())
+            'associative' => Arr::isAssoc($object->all()),
         ]);
     }
 

--- a/src/Support/Normalization/CollectionNormalizer.php
+++ b/src/Support/Normalization/CollectionNormalizer.php
@@ -35,7 +35,7 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
 
         return $fqcn::make($items)->mapWithKeys(
             fn ($value) => [
-                $value[0] => $this->serializer->denormalize($value[1], $subtype, $format, $context)
+                $value[0] => $this->serializer->denormalize($value[1], $subtype, $format, $context),
             ]
         );
     }

--- a/tests/Unit/CollectionNormalizerTest.php
+++ b/tests/Unit/CollectionNormalizerTest.php
@@ -98,6 +98,37 @@ it('can normalize a collection all of scalars', function () {
     }
 });
 
+it('can normalize a collection with keys and restore key order', function () {
+    $collection = Collection::make([
+        2 => 2,
+        1 => 1,
+        3 => 3,
+    ]);
+
+    $expected_json = '{"type":"int","items":[[2,2],[1,1],[3,3]]}';
+
+    $serializer = new SymfonySerializer(
+        normalizers: [$normalizer = new CollectionNormalizer()],
+        encoders: [new JsonEncoder()],
+    );
+
+    // We should be able to normalize
+    expect($normalizer->supportsNormalization($collection))->toBeTrue();
+    $normalized = $serializer->normalize($collection, 'json');
+
+    // And encode to JSON
+    $encoded = json_encode($normalized);
+    expect($encoded)->toBe($expected_json);
+
+    // And then denormalize that JSON
+    expect($normalizer->supportsDenormalization($encoded, Collection::class, 'json'))->toBeTrue();
+    $denormalized = $serializer->denormalize(json_decode($encoded), Collection::class);
+
+    // And the denormalized data should be the same
+    expect($denormalized)->toBeInstanceOf(Collection::class);
+    expect($denormalized->all())->toBe($collection->all());
+});
+
 it('can normalize a collection all of states', function () {
     $manager = app(StateManager::class);
 

--- a/tests/Unit/CollectionNormalizerTest.php
+++ b/tests/Unit/CollectionNormalizerTest.php
@@ -105,7 +105,7 @@ it('can normalize a collection with keys and restore key order', function () {
         3 => 3,
     ]);
 
-    $expected_json = '{"type":"int","items":[[2,2],[1,1],[3,3]]}';
+    $expected_json = '{"type":"int","items":[[2,2],[1,1],[3,3]],"assoc":true}';
 
     $serializer = new SymfonySerializer(
         normalizers: [$normalizer = new CollectionNormalizer()],

--- a/tests/Unit/CollectionNormalizerTest.php
+++ b/tests/Unit/CollectionNormalizerTest.php
@@ -105,7 +105,7 @@ it('can normalize a collection with keys and restore key order', function () {
         3 => 3,
     ]);
 
-    $expected_json = '{"type":"int","items":[[2,2],[1,1],[3,3]],"assoc":true}';
+    $expected_json = '{"type":"int","items":[[2,2],[1,1],[3,3]],"associative":true}';
 
     $serializer = new SymfonySerializer(
         normalizers: [$normalizer = new CollectionNormalizer()],


### PR DESCRIPTION
[MySQL has decided](https://dev.mysql.com/doc/refman/8.0/en/json.html#json-normalization) that it will sort all JSON columns keys alphabetically, so this breaks any collection sorted by keys.

This PR fixes that.