### PR TITLE
Check for `componentHook` before calling it

### DIFF
--- a/src/Models/VerbSnapshot.php
+++ b/src/Models/VerbSnapshot.php
@@ -9,11 +9,11 @@ use Thunk\Verbs\Support\Serializer;
 use UnexpectedValueException;
 
 /**
- * @property  int $id
- * @property  string $data
- * @property  int|null $last_event_id
- * @property  CarbonInterface $created_at
- * @property  CarbonInterface $updated_at
+ * @property int $id
+ * @property string $data
+ * @property int|null $last_event_id
+ * @property CarbonInterface $created_at
+ * @property CarbonInterface $updated_at
  */
 class VerbSnapshot extends Model
 {

--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -93,7 +93,12 @@ class VerbsServiceProvider extends PackageServiceProvider
         parent::boot();
 
         if ($this->app->has('livewire')) {
-            $this->app->make('livewire')->componentHook(SupportVerbs::class);
+            $manager = $this->app->make('livewire');
+
+            // Component hooks only exist in v3, so we need to check before registering our hook
+            if (method_exists($manager, 'componentHook')) {
+                $manager->componentHook(SupportVerbs::class);
+            }
         }
 
         $this->app->terminating(function () {


### PR DESCRIPTION
This was brought up on the [Verbs Discord](https://discord.com/channels/1176581731168567366/1176581732074532908/1197231950763667597) — Livewire v2 does not support component hooks, so we need to check if it's v3 before registering our `SupportVerbs` hook.