### PR TITLE
Add `for` method to factory

### DIFF
--- a/src/StateFactory.php
+++ b/src/StateFactory.php
@@ -6,15 +6,24 @@ use Thunk\Verbs\Events\VerbsStateInitialized;
 
 class StateFactory
 {
+    protected ?int $id = null;
+
     public function __construct(
         protected string $state_class
     ) {
     }
 
+    public function for(int $id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
     public function create(array $data, ?int $id = null): State
     {
         return VerbsStateInitialized::fire(
-            state_id: $id,
+            state_id: $id ?? $this->id,
             state_class: $this->state_class,
             state_data: $data
         )->state();

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Thunk\Verbs\State;
+
+test('a factory can accept an id using for method', function () {
+    $state = StateWithId::factory()->for(1)->create([
+        'name' => 'daniel',
+    ]);
+
+    expect($state->id)->toBe(1);
+    expect($state->name)->toBe('daniel');
+});
+
+class StateWithId extends State
+{
+    public string $name;
+}

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -2,12 +2,30 @@
 
 use Thunk\Verbs\State;
 
+test('a factory can accept an id using the create method', function () {
+    $state = StateWithId::factory()->create([
+        'name' => 'daniel',
+    ], 1);
+
+    expect($state->id)->toBe(1);
+    expect($state->name)->toBe('daniel');
+});
+
 test('a factory can accept an id using for method', function () {
     $state = StateWithId::factory()->for(1)->create([
         'name' => 'daniel',
     ]);
 
     expect($state->id)->toBe(1);
+    expect($state->name)->toBe('daniel');
+});
+
+test('a factory can accept an id using the create method over the for method', function () {
+    $state = StateWithId::factory()->for(1)->create([
+        'name' => 'daniel',
+    ], 2);
+
+    expect($state->id)->toBe(2);
     expect($state->name)->toBe('daniel');
 });
 


### PR DESCRIPTION
This PR allows you to pass the state id through a `for()` method instead of needing to pass it as a second parameter into the create method.

```php
MyState::factory()->for($myStateId)->create([...]);
```

The old way will still work
```php
MyState::factory()->create([...], $myStateId);
```

If for some reason, someone uses both, the ID passed into the create method will take preference.
```php
MyState::factory()->for($myStateId1)->create([...], $myStateId2); // This will have a state ID of 2
```
