### PR TITLE
Change state factory to not require an array to be passed in

### DIFF
--- a/src/StateFactory.php
+++ b/src/StateFactory.php
@@ -13,14 +13,14 @@ class StateFactory
     ) {
     }
 
-    public function for(int $id)
+    public function for(int $id): static
     {
         $this->id = $id;
 
         return $this;
     }
 
-    public function create(array $data, ?int $id = null): State
+    public function create(array $data = [], ?int $id = null): State
     {
         return VerbsStateInitialized::fire(
             state_id: $id ?? $this->id,

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -2,6 +2,20 @@
 
 use Thunk\Verbs\State;
 
+test('a factory can create a state', function () {
+    $state = StateWithId::factory()->create([
+        'name' => 'daniel',
+    ]);
+
+    expect($state->name)->toBe('daniel');
+});
+
+test('a factory without parameters can create a state', function () {
+    $state = StateWithId::factory()->create();
+
+    expect($state)->toBeInstanceOf(StateWithId::class);
+});
+
 test('a factory can accept an id using the create method', function () {
     $state = StateWithId::factory()->create([
         'name' => 'daniel',


### PR DESCRIPTION
This allows you to write `MyState::factory()->create()` without needing to pass an array into create `->create([])`, which is a familiar pattern in Laravel (although strictly not necessary with Verbs to create a state).