### PR TITLE
Fix the stupidest type check ever.

### DIFF
--- a/src/Lifecycle/Guards.php
+++ b/src/Lifecycle/Guards.php
@@ -67,8 +67,8 @@ class Guards
             if ($result instanceof Response) {
                 return $result->authorize();
             }
-
-            if ($result instanceof bool) {
+            
+            if (is_bool($result)) {
                 return $result;
             }
 

--- a/src/Lifecycle/Guards.php
+++ b/src/Lifecycle/Guards.php
@@ -67,7 +67,7 @@ class Guards
             if ($result instanceof Response) {
                 return $result->authorize();
             }
-            
+
             if (is_bool($result)) {
                 return $result;
             }

--- a/tests/Feature/PendingEventChecksTest.php
+++ b/tests/Feature/PendingEventChecksTest.php
@@ -29,7 +29,7 @@ it('supports boolean authorization', function () {
 
     $this->assertTrue($event->isAllowed());
 
-    $event =  EventWithBooleanAuth::make([
+    $event = EventWithBooleanAuth::make([
         'allowed' => false,
     ]);
 
@@ -73,7 +73,6 @@ it('can test validation on a pending event', function () {
 
     $this->assertFalse($event->isValid());
 });
-
 
 class EventWithBooleanAuth extends Event
 {

--- a/tests/Feature/PendingEventChecksTest.php
+++ b/tests/Feature/PendingEventChecksTest.php
@@ -22,6 +22,20 @@ it('can test authorization on a pending event', function () {
     $this->assertFalse($event->isAllowed());
 });
 
+it('supports boolean authorization', function () {
+    $event = EventWithBooleanAuth::make([
+        'allowed' => true,
+    ]);
+
+    $this->assertTrue($event->isAllowed());
+
+    $event =  EventWithBooleanAuth::make([
+        'allowed' => false,
+    ]);
+
+    $this->assertFalse($event->isAllowed());
+});
+
 it('can test validation on a pending event', function () {
     SpecialState::factory()->create([
         'name' => 'daniel',
@@ -59,6 +73,17 @@ it('can test validation on a pending event', function () {
 
     $this->assertFalse($event->isValid());
 });
+
+
+class EventWithBooleanAuth extends Event
+{
+    public bool $allowed;
+
+    public function authorize()
+    {
+        return $this->allowed;
+    }
+}
 
 class EventWithMultipleStates extends Event
 {


### PR DESCRIPTION
hilariously `$result instanceof bool` is not identical to `is_bool($result)` because of too many boolean types in this very good language.