### PR TITLE
Event store testing

### DIFF
--- a/src/Commands/ReplayCommand.php
+++ b/src/Commands/ReplayCommand.php
@@ -3,8 +3,8 @@
 namespace Thunk\Verbs\Commands;
 
 use Illuminate\Console\Command;
+use Thunk\Verbs\Contracts\BrokersEvents;
 use Thunk\Verbs\Event;
-use Thunk\Verbs\Lifecycle\Broker;
 
 class ReplayCommand extends Command
 {
@@ -12,7 +12,7 @@ class ReplayCommand extends Command
 
     protected $description = 'Replay all Verbs events.';
 
-    public function handle(Broker $broker): void
+    public function handle(BrokersEvents $broker): void
     {
         $broker->replay(
             beforeEach: fn (Event $event) => $this->getOutput()->write(sprintf(

--- a/src/Contracts/BrokersEvents.php
+++ b/src/Contracts/BrokersEvents.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Thunk\Verbs\Contracts;
+
+use Glhd\Bits\Bits;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Uid\AbstractUid;
+use Thunk\Verbs\Event;
+
+interface BrokersEvents
+{
+    public function fire(Event $event): ?Event;
+
+    public function commit(): bool;
+
+    public function isValid(Event $event): bool;
+
+    public function isAllowed(Event $event): bool;
+
+    public function replay(?callable $beforeEach = null, ?callable $afterEach = null);
+
+    public function isReplaying(): bool;
+
+    public function unlessReplaying(callable $callback);
+
+    public function createMetadataUsing(?callable $callback = null): void;
+
+    public function toId(Bits|UuidInterface|AbstractUid|int|string|null $id): int|string|null;
+
+    public function commitImmediately(bool $commit_immediately = true): void;
+}

--- a/src/Contracts/StoresEvents.php
+++ b/src/Contracts/StoresEvents.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Thunk\Verbs\Contracts;
+
+use Glhd\Bits\Bits;
+use Illuminate\Support\LazyCollection;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Uid\AbstractUid;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\State;
+
+interface StoresEvents
+{
+    public function read(
+        ?State $state = null,
+        Bits|UuidInterface|AbstractUid|int|string|null $after_id = null,
+        Bits|UuidInterface|AbstractUid|int|string|null $up_to_id = null,
+        bool $singleton = false
+    ): LazyCollection;
+
+    /** @param  Event[]  $events */
+    public function write(array $events): bool;
+}

--- a/src/Facades/Verbs.php
+++ b/src/Facades/Verbs.php
@@ -2,9 +2,12 @@
 
 namespace Thunk\Verbs\Facades;
 
+use Closure;
 use Illuminate\Support\Facades\Facade;
 use Thunk\Verbs\Contracts\BrokersEvents;
 use Thunk\Verbs\Event;
+use Thunk\Verbs\Testing\BrokerFake;
+use Thunk\Verbs\Testing\EventStoreFake;
 
 /**
  * @method static bool commit()
@@ -14,9 +17,34 @@ use Thunk\Verbs\Event;
  * @method static Event fire(Event $event)
  * @method static void createMetadataUsing(callable $callback)
  * @method static void commitImmediately(bool $commit_immediately = true)
+ * @method static EventStoreFake assertCommitted(string|Closure $event, Closure|int|null $callback = null)
+ * @method static EventStoreFake assertNotCommitted(string|Closure $event, ?Closure $callback = null)
+ * @method static EventStoreFake assertNothingCommitted()
  */
 class Verbs extends Facade
 {
+    public static function fake()
+    {
+        $real_broker = static::isFake()
+            ? static::getFacadeRoot()->broker
+            : static::getFacadeRoot();
+
+        $fake_broker = new BrokerFake(
+            static::getFacadeApplication(),
+            static::getFacadeApplication()->make(EventStoreFake::class),
+            $real_broker
+        );
+
+        static::swap($fake_broker);
+
+        return $fake_broker;
+    }
+
+    public static function getFacadeRoot(): BrokersEvents
+    {
+        return parent::getFacadeRoot();
+    }
+
     protected static function getFacadeAccessor()
     {
         return BrokersEvents::class;

--- a/src/Facades/Verbs.php
+++ b/src/Facades/Verbs.php
@@ -14,6 +14,7 @@ use Thunk\Verbs\Lifecycle\Broker;
  * @method static Event fire(Event $event)
  * @method static void createMetadataUsing(callable $callback)
  * @method static void commitImmediately(bool $commit_immediately = true)
+ * @method static void fake()
  */
 class Verbs extends Facade
 {

--- a/src/Facades/Verbs.php
+++ b/src/Facades/Verbs.php
@@ -3,8 +3,8 @@
 namespace Thunk\Verbs\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Thunk\Verbs\Contracts\BrokersEvents;
 use Thunk\Verbs\Event;
-use Thunk\Verbs\Lifecycle\Broker;
 
 /**
  * @method static bool commit()
@@ -14,12 +14,11 @@ use Thunk\Verbs\Lifecycle\Broker;
  * @method static Event fire(Event $event)
  * @method static void createMetadataUsing(callable $callback)
  * @method static void commitImmediately(bool $commit_immediately = true)
- * @method static void fake()
  */
 class Verbs extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return Broker::class;
+        return BrokersEvents::class;
     }
 }

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -7,11 +7,12 @@ use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Uid\AbstractUid;
 use Throwable;
 use Thunk\Verbs\CommitsImmediately;
+use Thunk\Verbs\Contracts\BrokersEvents;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Exceptions\EventNotValidForCurrentState;
 use Thunk\Verbs\Lifecycle\Queue as EventQueue;
 
-class Broker
+class Broker implements BrokersEvents
 {
     public bool $is_replaying = false;
 

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -2,19 +2,14 @@
 
 namespace Thunk\Verbs\Lifecycle;
 
-use Glhd\Bits\Bits;
-use Ramsey\Uuid\UuidInterface;
-use Symfony\Component\Uid\AbstractUid;
-use Throwable;
 use Thunk\Verbs\CommitsImmediately;
 use Thunk\Verbs\Contracts\BrokersEvents;
 use Thunk\Verbs\Event;
-use Thunk\Verbs\Exceptions\EventNotValidForCurrentState;
 use Thunk\Verbs\Lifecycle\Queue as EventQueue;
 
 class Broker implements BrokersEvents
 {
-    public bool $is_replaying = false;
+    use BrokerConvenienceMethods;
 
     public bool $commit_immediately = false;
 
@@ -71,34 +66,6 @@ class Broker implements BrokersEvents
         return $this->commit();
     }
 
-    public function isValid(Event $event): bool
-    {
-        try {
-            $states = $event->states();
-
-            Guards::for($event, null)->validate();
-            $states->each(fn ($state) => Guards::for($event, $state)->validate());
-
-            return true;
-        } catch (EventNotValidForCurrentState $e) {
-            return false;
-        }
-    }
-
-    public function isAllowed(Event $event): bool
-    {
-        try {
-            $states = $event->states();
-
-            Guards::for($event, null)->authorize();
-            $states->each(fn ($state) => Guards::for($event, $state)->authorize());
-
-            return true;
-        } catch (Throwable $e) {
-            return false;
-        }
-    }
-
     public function replay(?callable $beforeEach = null, ?callable $afterEach = null)
     {
         $this->is_replaying = true;
@@ -126,33 +93,6 @@ class Broker implements BrokersEvents
             });
 
         $this->is_replaying = false;
-    }
-
-    public function isReplaying(): bool
-    {
-        return $this->is_replaying;
-    }
-
-    public function unlessReplaying(callable $callback)
-    {
-        if (! $this->is_replaying) {
-            $callback();
-        }
-    }
-
-    public function createMetadataUsing(?callable $callback = null): void
-    {
-        app(MetadataManager::class)->createMetadataUsing($callback);
-    }
-
-    public function toId(Bits|UuidInterface|AbstractUid|int|string|null $id): int|string|null
-    {
-        return match (true) {
-            $id instanceof Bits => $id->id(),
-            $id instanceof UuidInterface => $id->toString(),
-            $id instanceof AbstractUid => (string) $id,
-            default => $id,
-        };
     }
 
     public function commitImmediately(bool $commit_immediately = true): void

--- a/src/Lifecycle/BrokerConvenienceMethods.php
+++ b/src/Lifecycle/BrokerConvenienceMethods.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Thunk\Verbs\Lifecycle;
+
+use Glhd\Bits\Bits;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Uid\AbstractUid;
+use Throwable;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Exceptions\EventNotValidForCurrentState;
+
+trait BrokerConvenienceMethods
+{
+    public bool $is_replaying = false;
+
+    public function createMetadataUsing(?callable $callback = null): void
+    {
+        app(MetadataManager::class)->createMetadataUsing($callback);
+    }
+
+    public function isValid(Event $event): bool
+    {
+        try {
+            $states = $event->states();
+
+            Guards::for($event, null)->validate();
+            $states->each(fn ($state) => Guards::for($event, $state)->validate());
+
+            return true;
+        } catch (EventNotValidForCurrentState $e) {
+            return false;
+        }
+    }
+
+    public function isReplaying(): bool
+    {
+        return $this->is_replaying;
+    }
+
+    public function isAllowed(Event $event): bool
+    {
+        try {
+            $states = $event->states();
+
+            Guards::for($event, null)->authorize();
+            $states->each(fn ($state) => Guards::for($event, $state)->authorize());
+
+            return true;
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    public function toId(Bits|UuidInterface|AbstractUid|int|string|null $id): int|string|null
+    {
+        return match (true) {
+            $id instanceof Bits => $id->id(),
+            $id instanceof UuidInterface => $id->toString(),
+            $id instanceof AbstractUid => (string) $id,
+            default => $id,
+        };
+    }
+
+    public function unlessReplaying(callable $callback)
+    {
+        if (! $this->is_replaying) {
+            $callback();
+        }
+    }
+}

--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -7,6 +7,7 @@ use Glhd\Bits\Snowflake;
 use Illuminate\Database\Eloquent\Collection;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Uid\AbstractUid;
+use Thunk\Verbs\Contracts\StoresEvents;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\State;
@@ -22,7 +23,7 @@ class StateManager
     public function __construct(
         protected Dispatcher $dispatcher,
         protected SnapshotStore $snapshots,
-        protected EventStore $events,
+        protected StoresEvents $events,
     ) {
         $this->states = new Collection();
     }

--- a/src/Support/PendingEvent.php
+++ b/src/Support/PendingEvent.php
@@ -13,8 +13,8 @@ use ReflectionMethod;
 use ReflectionParameter;
 use RuntimeException;
 use Throwable;
+use Thunk\Verbs\Contracts\BrokersEvents;
 use Thunk\Verbs\Event;
-use Thunk\Verbs\Lifecycle\Broker;
 use Thunk\Verbs\Lifecycle\MetadataManager;
 
 /**
@@ -104,7 +104,7 @@ class PendingEvent
         }
 
         try {
-            return app(Broker::class)->fire($this->event);
+            return app(BrokersEvents::class)->fire($this->event);
         } catch (Throwable $e) {
             throw $this->prepareException($e);
         }
@@ -115,7 +115,7 @@ class PendingEvent
     {
         $event = $this->fire(...$args);
 
-        app(Broker::class)->commit();
+        app(BrokersEvents::class)->commit();
 
         $results = app(MetadataManager::class)->getLastResults($event);
 
@@ -124,12 +124,12 @@ class PendingEvent
 
     public function isAllowed(): bool
     {
-        return app(Broker::class)->isAllowed($this->event);
+        return app(BrokersEvents::class)->isAllowed($this->event);
     }
 
     public function isValid(): bool
     {
-        return app(Broker::class)->isValid($this->event);
+        return app(BrokersEvents::class)->isValid($this->event);
     }
 
     /** @param  callable(Throwable): Throwable  $handler */

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -4,6 +4,12 @@ use Thunk\Verbs\Event;
 use Thunk\Verbs\Support\PendingEvent;
 
 if (! function_exists('verb')) {
+    /**
+     * @template TEventType
+     *
+     * @param  Event<TEventType>  $event
+     * @return Event<TEventType>
+     */
     function verb(Event $event, bool $commit = false): Event
     {
         $pending = new PendingEvent($event);

--- a/src/Testing/BrokerFake.php
+++ b/src/Testing/BrokerFake.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Thunk\Verbs\Testing;
+
+use Closure;
+use Illuminate\Contracts\Container\Container;
+use Thunk\Verbs\Contracts\BrokersEvents;
+use Thunk\Verbs\Contracts\StoresEvents;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Lifecycle\Broker;
+use Thunk\Verbs\Lifecycle\BrokerConvenienceMethods;
+
+class BrokerFake implements BrokersEvents
+{
+    use BrokerConvenienceMethods;
+
+    public function __construct(
+        Container $container,
+        public EventStoreFake $store,
+        public Broker $broker,
+    ) {
+        // Eventually this will swap out all the necessary fakes and implement
+        // our own versions of fire/commit/replay, but for now this is just a
+        // placeholder class.
+        //
+        //  - [x] EventStore
+        //  - [ ] EventQueue
+        //  - [ ] SnapshotStore
+        //  - [ ] StateManager (might only need to fake this instead of snapshot store)
+
+        $container->instance(StoresEvents::class, $this->store);
+    }
+
+    public function assertCommitted(string|Closure $event, Closure|int|null $callback = null): EventStoreFake
+    {
+        return $this->store->assertCommitted($event, $callback);
+    }
+
+    public function assertNotCommitted(string|Closure $event, ?Closure $callback = null): EventStoreFake
+    {
+        return $this->store->assertNotCommitted($event, $callback);
+    }
+
+    public function assertNothingCommitted(): EventStoreFake
+    {
+        return $this->store->assertNothingCommitted();
+    }
+
+    public function fire(Event $event): ?Event
+    {
+        return $this->broker->fire($event);
+    }
+
+    public function commit(): bool
+    {
+        return $this->broker->commit();
+    }
+
+    public function replay(?callable $beforeEach = null, ?callable $afterEach = null)
+    {
+        $this->broker->replay($beforeEach, $afterEach);
+    }
+
+    public function commitImmediately(bool $commit_immediately = true): void
+    {
+        $this->broker->commitImmediately($commit_immediately);
+    }
+}

--- a/src/Testing/EventStoreFake.php
+++ b/src/Testing/EventStoreFake.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Thunk\Verbs\Testing;
+
+use Closure;
+use Glhd\Bits\Bits;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Traits\ReflectsClosures;
+use PHPUnit\Framework\Assert as PHPUnit;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Uid\AbstractUid;
+use Thunk\Verbs\Contracts\StoresEvents;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+use Thunk\Verbs\Lifecycle\MetadataManager;
+use Thunk\Verbs\State;
+
+class EventStoreFake implements StoresEvents
+{
+    use ReflectsClosures;
+
+    /** @var Collection<int, Collection<int, Event>> */
+    protected Collection $events;
+
+    public function __construct(
+        protected MetadataManager $metadata,
+    ) {
+        $this->events = new Collection();
+    }
+
+    public function read(
+        ?State $state = null,
+        UuidInterface|string|int|AbstractUid|Bits|null $after_id = null,
+        UuidInterface|string|int|AbstractUid|Bits|null $up_to_id = null,
+        bool $singleton = false
+    ): LazyCollection {
+        return LazyCollection::make($this->events)
+            ->flatten()
+            ->when($after_id, function (LazyCollection $events, $after_id) {
+                return $events->filter(fn (Event $event) => $event->id > Verbs::toId($after_id));
+            })
+            ->when($up_to_id, function (LazyCollection $events, $up_to_id) {
+                return $events->filter(fn (Event $event) => $event->id <= Verbs::toId($up_to_id));
+            })
+            ->when($state, function (LazyCollection $events, State $state) use ($singleton) {
+                return $singleton
+                    ? $events->filter(fn (Event $event) => $event->state($state::class) !== null)
+                    : $events->filter(fn (Event $event) => $event->state($state::class)->id === $state->id);
+            })
+            ->values();
+    }
+
+    public function write(array $events): bool
+    {
+        foreach ($events as $event) {
+            $this->events[$event::class] ??= new Collection();
+            $this->events[$event::class]->push($event);
+        }
+
+        return true;
+    }
+
+    /** @return Collection<int, Event> */
+    public function committed(string $class_name, ?Closure $filter = null): Collection
+    {
+        if (! $this->hasCommitted($class_name)) {
+            return new Collection();
+        }
+
+        return $this->events[$class_name]
+            ->when($filter !== null, fn ($events) => $events->filter($filter))
+            ->values();
+    }
+
+    public function hasCommitted($event): bool
+    {
+        return $this->events->has($event)
+            && $this->events->get($event)->isNotEmpty();
+    }
+
+    public function assertCommitted(string|Closure $event, Closure|int|null $callback = null): static
+    {
+        if ($event instanceof Closure) {
+            [$event, $callback] = [$this->firstClosureParameterType($event), $event];
+        }
+
+        if (is_int($callback)) {
+            return $this->assertCommittedTimes($event, $callback);
+        }
+
+        PHPUnit::assertTrue(
+            $this->committed($event, $callback)->count() > 0,
+            "The expected [{$event}] event was not committed."
+        );
+
+        return $this;
+    }
+
+    public function assertNotCommitted(string|Closure $event, ?Closure $callback = null): static
+    {
+        if ($event instanceof Closure) {
+            [$event, $callback] = [$this->firstClosureParameterType($event), $event];
+        }
+
+        PHPUnit::assertCount(
+            0, $this->committed($event, $callback),
+            "The unexpected [{$event}] event was committed."
+        );
+
+        return $this;
+    }
+
+    public function assertNothingCommitted(): static
+    {
+        PHPUnit::assertEmpty($this->events, 'Events were committed unexpectedly.');
+
+        return $this;
+    }
+
+    protected function assertCommittedTimes(string $class_name, int $times = 1): static
+    {
+        $count = $this->committed($class_name)->count();
+
+        PHPUnit::assertSame(
+            expected: $times,
+            actual: $count,
+            message: "The expected [{$class_name}] event was committed {$count} times instead of {$times} times.",
+        );
+
+        return $this;
+    }
+}

--- a/tests/Feature/VerbFakesTest.php
+++ b/tests/Feature/VerbFakesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Glhd\Bits\Snowflake;
+use Thunk\Verbs\Contracts\StoresEvents;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+
+it('performs event store assertions', function () {
+    Verbs::fake();
+
+    // assertNothingCommitted
+    Verbs::assertNothingCommitted();
+
+    app(StoresEvents::class)->write([
+        $event1 = new VerbFakesTestEvent(),
+        $event2 = new VerbFakesTestEvent(),
+        $event3 = new VerbFakesTestEvent(),
+        $event4 = new VerbFakesTestEvent(),
+        $event5 = new VerbFakesTestEvent(),
+    ]);
+
+    // assertCommitted() with type-hinted callback
+    Verbs::assertCommitted(fn (VerbFakesTestEvent $event) => $event->id === $event1->id);
+    Verbs::assertCommitted(fn (VerbFakesTestEvent $event) => $event->id === $event2->id);
+    Verbs::assertCommitted(fn (VerbFakesTestEvent $event) => $event->id === $event3->id);
+    Verbs::assertCommitted(fn (VerbFakesTestEvent $event) => $event->id === $event4->id);
+    Verbs::assertCommitted(fn (VerbFakesTestEvent $event) => $event->id === $event5->id);
+
+    // assertCommitted() with explicitly-typed callback
+    Verbs::assertCommitted(VerbFakesTestEvent::class, fn ($event) => $event->id === $event1->id);
+    Verbs::assertCommitted(VerbFakesTestEvent::class, fn ($event) => $event->id === $event2->id);
+    Verbs::assertCommitted(VerbFakesTestEvent::class, fn ($event) => $event->id === $event3->id);
+    Verbs::assertCommitted(VerbFakesTestEvent::class, fn ($event) => $event->id === $event4->id);
+    Verbs::assertCommitted(VerbFakesTestEvent::class, fn ($event) => $event->id === $event5->id);
+
+    // assertCommitted() with class name
+    Verbs::assertCommitted(VerbFakesTestEvent::class);
+    Verbs::assertCommitted(VerbFakesTestEvent::class, 5);
+
+    // assertNotCommitted() with type-hinted callback
+    Verbs::assertNotCommitted(fn (VerbFakesTestEvent $event) => $event->id === 0);
+    Verbs::assertNotCommitted(fn (UncommittedVerbFakesTestEvent $event) => $event->id === 0);
+
+    // assertNotCommitted() with explicitly-typed callback
+    Verbs::assertNotCommitted(VerbFakesTestEvent::class, fn ($event) => $event->id === 0);
+    Verbs::assertNotCommitted(UncommittedVerbFakesTestEvent::class, fn ($event) => $event->id === 0);
+});
+
+class VerbFakesTestEvent extends Event
+{
+    public function __construct(?int $id = null)
+    {
+        $this->id = $id ?? Snowflake::make()->id();
+    }
+}
+
+class UncommittedVerbFakesTestEvent extends Event
+{
+    public function __construct(?int $id = null)
+    {
+        $this->id = $id ?? Snowflake::make()->id();
+    }
+}

--- a/tests/Unit/EventStoreFakeTest.php
+++ b/tests/Unit/EventStoreFakeTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use Glhd\Bits\Snowflake;
+use Thunk\Verbs\Attributes\Autodiscovery\AppliesToState;
+use Thunk\Verbs\Contracts\StoresEvents;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Lifecycle\MetadataManager;
+use Thunk\Verbs\Lifecycle\StateManager;
+use Thunk\Verbs\State;
+use Thunk\Verbs\Testing\EventStoreFake;
+
+it('performs assertions', function () {
+    $store = new EventStoreFake(app(MetadataManager::class));
+
+    // assertNothingCommitted
+    $store->assertNothingCommitted();
+
+    $store->write([
+        $event1 = new EventStoreFakeTestEvent(),
+        $event2 = new EventStoreFakeTestEvent(),
+        $event3 = new EventStoreFakeTestEvent(),
+        $event4 = new EventStoreFakeTestEvent(),
+        $event5 = new EventStoreFakeTestEvent(),
+    ]);
+
+    // committed() and hasCommitted()
+    expect($store->committed(EventStoreFakeTestEvent::class)->count())->toBe(5)
+        ->and($store->committed(UncommittedEventStoreFakeTestEvent::class)->count())->toBe(0)
+        ->and($store->hasCommitted(EventStoreFakeTestEvent::class))->toBeTrue()
+        ->and($store->hasCommitted(UncommittedEventStoreFakeTestEvent::class))->toBeFalse();
+
+    // assertCommitted() with type-hinted callback
+    $store->assertCommitted(fn (EventStoreFakeTestEvent $event) => $event->id === $event1->id);
+    $store->assertCommitted(fn (EventStoreFakeTestEvent $event) => $event->id === $event2->id);
+    $store->assertCommitted(fn (EventStoreFakeTestEvent $event) => $event->id === $event3->id);
+    $store->assertCommitted(fn (EventStoreFakeTestEvent $event) => $event->id === $event4->id);
+    $store->assertCommitted(fn (EventStoreFakeTestEvent $event) => $event->id === $event5->id);
+
+    // assertCommitted() with explicitly-typed callback
+    $store->assertCommitted(EventStoreFakeTestEvent::class, fn ($event) => $event->id === $event1->id);
+    $store->assertCommitted(EventStoreFakeTestEvent::class, fn ($event) => $event->id === $event2->id);
+    $store->assertCommitted(EventStoreFakeTestEvent::class, fn ($event) => $event->id === $event3->id);
+    $store->assertCommitted(EventStoreFakeTestEvent::class, fn ($event) => $event->id === $event4->id);
+    $store->assertCommitted(EventStoreFakeTestEvent::class, fn ($event) => $event->id === $event5->id);
+
+    // assertCommitted() with class name
+    $store->assertCommitted(EventStoreFakeTestEvent::class);
+    $store->assertCommitted(EventStoreFakeTestEvent::class, 5);
+
+    // assertNotCommitted() with type-hinted callback
+    $store->assertNotCommitted(fn (EventStoreFakeTestEvent $event) => $event->id === 0);
+    $store->assertNotCommitted(fn (UncommittedEventStoreFakeTestEvent $event) => $event->id === 0);
+
+    // assertNotCommitted() with explicitly-typed callback
+    $store->assertNotCommitted(EventStoreFakeTestEvent::class, fn ($event) => $event->id === 0);
+    $store->assertNotCommitted(UncommittedEventStoreFakeTestEvent::class, fn ($event) => $event->id === 0);
+});
+
+it('reads and writes stateless events normally', function () {
+    $store = new EventStoreFake(app(MetadataManager::class));
+
+    $store->write([
+        new EventStoreFakeTestEvent(1),
+        new EventStoreFakeTestEvent(2),
+        new EventStoreFakeTestEvent(3),
+        new EventStoreFakeTestEvent(4),
+        new EventStoreFakeTestEvent(5),
+    ]);
+
+    expect($store->read()->map(fn (Event $event) => $event->id)->all())
+        ->toBe([1, 2, 3, 4, 5])
+        ->and($store->read(after_id: 2)->map(fn (Event $event) => $event->id)->all())
+        ->toBe([3, 4, 5])
+        ->and($store->read(up_to_id: 4)->map(fn (Event $event) => $event->id)->all())
+        ->toBe([1, 2, 3, 4])
+        ->and($store->read(after_id: 2, up_to_id: 4)->map(fn (Event $event) => $event->id)->all())
+        ->toBe([3, 4]);
+});
+
+it('reads and writes stateful events normally', function () {
+    app()->instance(StoresEvents::class, $store = new EventStoreFake(app(MetadataManager::class)));
+
+    $state1 = app(StateManager::class)->load(
+        1001,
+        type: EventStoreFakeTestState::class,
+    );
+
+    $state2 = app(StateManager::class)->load(
+        1002,
+        type: EventStoreFakeTestState::class,
+    );
+
+    // State IDs = 100X, Event IDs = X0Y (X = state, Y = event)
+
+    $store->write([
+        new EventStoreFakeTestStatefulEvent(state_id: 1001, id: 101),
+        new EventStoreFakeTestStatefulEvent(state_id: 1002, id: 201),
+        new EventStoreFakeTestStatefulEvent(state_id: 1001, id: 102),
+        new EventStoreFakeTestStatefulEvent(state_id: 1002, id: 202),
+        new EventStoreFakeTestStatefulEvent(state_id: 1002, id: 203),
+        new EventStoreFakeTestStatefulEvent(state_id: 1001, id: 103),
+    ]);
+
+    expect($store->read(state: $state1)->map(fn (Event $event) => $event->id)->all())
+        ->toBe([101, 102, 103])
+        ->and($store->read(state: $state2)->map(fn (Event $event) => $event->id)->all())
+        ->toBe([201, 202, 203])
+        ->and($store->read(state: $state2, after_id: 201)->map(fn (Event $event) => $event->id)->all())
+        ->toBe([202, 203])
+        ->and($store->read(state: $state2, up_to_id: 202)->map(fn (Event $event) => $event->id)->all())
+        ->toBe([201, 202])
+        ->and($store->read(state: $state2, after_id: 201, up_to_id: 202)->map(fn (Event $event) => $event->id)->all())
+        ->toBe([202]);
+});
+
+class EventStoreFakeTestEvent extends Event
+{
+    public function __construct(?int $id = null)
+    {
+        $this->id = $id ?? Snowflake::make()->id();
+    }
+}
+
+class UncommittedEventStoreFakeTestEvent extends Event
+{
+    public function __construct(?int $id = null)
+    {
+        $this->id = $id ?? Snowflake::make()->id();
+    }
+}
+
+class EventStoreFakeTestState extends State
+{
+}
+
+#[AppliesToState(EventStoreFakeTestState::class, 'state_id')]
+class EventStoreFakeTestStatefulEvent extends Event
+{
+    public function __construct(
+        public ?int $state_id = null,
+        ?int $id = null
+    ) {
+        $this->id = $id ?? Snowflake::make()->id();
+    }
+}


### PR DESCRIPTION
This provides a way to fake the `EventStore` and test with:

```php
Verbs::assertNothingCommitted();
Verbs::assertCommitted(...);
Verbs::assertNotCommitted(...);
```

It's a step towards full testing affordances for the stores/queue/and state manager.