### PR TITLE
Improve IDE/static analysis support

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://laravel-ide.com/schema/laravel-ide-v2.json",
+    "completions": [
+        {
+            "complete": "classFields",
+            "options": {
+                "fieldsFilter": {
+                    "fetch": "own",
+                    "modifier": [
+                        "public"
+                    ]
+                }
+            },
+            "condition": [
+                {
+                    "methodNames": [
+                        "make",
+                        "fire"
+                    ],
+                    "parameters": [
+                        1
+                    ],
+                    "classFqn": [
+                        "\\Thunk\\Verbs\\Event"
+                    ],
+                    "place": "arrayKey"
+                }
+            ]
+        }
+    ]
+}

--- a/ide.json
+++ b/ide.json
@@ -27,5 +27,22 @@
                 }
             ]
         }
-    ]
+    ],
+    "helperCode": {
+        "methodsWithConstructorParameters": [
+            {
+                "baseFqn": "Thunk\\Verbs\\Event",
+                "methods": [
+                    {
+                        "name": "make",
+                        "returnType": "PendingEvent<$this>"
+                    },
+                    {
+                        "name": "fire",
+                        "returnType": "$this"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/src/Attributes/Autodiscovery/StateId.php
+++ b/src/Attributes/Autodiscovery/StateId.php
@@ -12,6 +12,7 @@ use Thunk\Verbs\State;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class StateId extends StateDiscoveryAttribute
 {
+    /** @param  class-string<State>  $state_type */
     public function __construct(
         public string $state_type,
         public ?string $alias = null,

--- a/src/Event.php
+++ b/src/Event.php
@@ -23,7 +23,8 @@ abstract class Event
         return static::make()->$name(...$arguments);
     }
 
-    public static function make(...$args)
+    /** @return PendingEvent<$this> */
+    public static function make(...$args): PendingEvent
     {
         return PendingEvent::make(static::class, $args);
     }
@@ -43,10 +44,10 @@ abstract class Event
     }
 
     /**
-     * @template T
+     * @template TStateType
      *
-     * @param  class-string<T>|null  $state_type
-     * @return T|null
+     * @param  class-string<TStateType>|null  $state_type
+     * @return TStateType|State|null
      */
     public function state(?string $state_type = null): ?State
     {

--- a/src/Event.php
+++ b/src/Event.php
@@ -44,7 +44,7 @@ abstract class Event
     }
 
     /**
-     * @template TStateType
+     * @template TStateType of State
      *
      * @param  class-string<TStateType>|null  $state_type
      * @return TStateType|State|null

--- a/src/Support/PendingEvent.php
+++ b/src/Support/PendingEvent.php
@@ -17,9 +17,9 @@ use Thunk\Verbs\Event;
 use Thunk\Verbs\Lifecycle\MetadataManager;
 
 /**
- * @template T
+ * @template TEventType of Event
  *
- * @property T $event
+ * @property TEventType $event
  */
 class PendingEvent
 {
@@ -27,7 +27,10 @@ class PendingEvent
 
     protected Closure $exception_mapper;
 
-    /** @param  class-string<Event>  $class_name */
+    /**
+     * @param  class-string<TEventType>  $class_name
+     * @return static<TEventType>
+     */
     public static function make(string $class_name, array $args): static
     {
         $args = static::normalizeArgs($args);
@@ -71,6 +74,7 @@ class PendingEvent
             ->all();
     }
 
+    /** @param  TEventType|class-string<TEventType>  $event */
     public function __construct(
         public Event|string $event,
     ) {
@@ -96,6 +100,7 @@ class PendingEvent
         return $this;
     }
 
+    /** @return null|TEventType */
     public function fire(...$args): ?Event
     {
         if (! empty($args) || is_string($this->event)) {

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -1,19 +1,24 @@
 <?php
 
+use Thunk\Verbs\Contracts\BrokersEvents;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Support\PendingEvent;
 
 if (! function_exists('verb')) {
     /**
-     * @template TEventType
+     * @template TEventType of Event
      *
-     * @param  Event<TEventType>  $event
-     * @return Event<TEventType>
+     * @param  TEventType  $event
+     * @return TEventType
      */
     function verb(Event $event, bool $commit = false): Event
     {
-        $pending = new PendingEvent($event);
+        $event = (new PendingEvent($event))->fire();
 
-        return $commit ? $pending->commit() : $pending->fire();
+        if ($commit) {
+            app(BrokersEvents::class)->commit();
+        }
+
+        return $event;
     }
 }


### PR DESCRIPTION
This just adds a few IDE/static analysis niceties:

### Auto-complete for arrays on `fire()` and `make()`
<img width="628" alt="image" src="https://github.com/hirethunk/verbs/assets/21592/fd799388-6f06-4a33-b5e4-49ab8295e3ed">

\* This required Laravel IDEA and PhpStorm

### Auto-complete on `verb()` helper
<img width="768" alt="image" src="https://github.com/hirethunk/verbs/assets/21592/bbc000eb-fb12-4325-bad4-8dc37ebf3219">

### Auto-complete on pending events
<img width="805" alt="image" src="https://github.com/hirethunk/verbs/assets/21592/8f418ea3-2591-45f8-9415-8b3aea214357">
<img width="731" alt="image" src="https://github.com/hirethunk/verbs/assets/21592/35f3f99c-b167-4c5b-8aed-56794b056f36">
