### PR TITLE
Rename `isAllowed` to `isAuthorized`

### DIFF
--- a/src/Contracts/BrokersEvents.php
+++ b/src/Contracts/BrokersEvents.php
@@ -10,9 +10,9 @@ interface BrokersEvents
 
     public function commit(): bool;
 
-    public function isValid(Event $event): bool;
+    public function isAuthorized(Event $event): bool;
 
-    public function isAllowed(Event $event): bool;
+    public function isValid(Event $event): bool;
 
     public function replay(?callable $beforeEach = null, ?callable $afterEach = null);
 }

--- a/src/Event.php
+++ b/src/Event.php
@@ -2,10 +2,8 @@
 
 namespace Thunk\Verbs;
 
-use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use InvalidArgumentException;
 use LogicException;
 use Throwable;
 use Thunk\Verbs\Exceptions\EventNotAuthorized;
@@ -73,15 +71,15 @@ abstract class Event
 
     protected function assert($assertion, ?string $exception = null, ?string $message = null): static
     {
-        if ($exception && null === $message && ! is_a($exception, Throwable::class, true)) {
+        if ($exception && $message === null && ! is_a($exception, Throwable::class, true)) {
             [$message, $exception] = [$exception, null];
         }
 
-        if (null === $message) {
+        if ($message === null) {
             $message = 'The event is not valid';
         }
 
-        if (null === $exception) {
+        if ($exception === null) {
             $caller = Arr::first(
                 debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2),
                 static fn ($trace) => ($trace['function'] ?? 'assert') !== 'assert'

--- a/src/Exceptions/EventNotAuthorized.php
+++ b/src/Exceptions/EventNotAuthorized.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Thunk\Verbs\Exceptions;
+
+use Illuminate\Auth\Access\AuthorizationException;
+
+class EventNotAuthorized extends AuthorizationException
+{
+}

--- a/src/Exceptions/EventNotValid.php
+++ b/src/Exceptions/EventNotValid.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Thunk\Verbs\Exceptions;
+
+use InvalidArgumentException;
+
+class EventNotValid extends InvalidArgumentException
+{
+}

--- a/src/Exceptions/EventNotValidForCurrentState.php
+++ b/src/Exceptions/EventNotValidForCurrentState.php
@@ -2,8 +2,6 @@
 
 namespace Thunk\Verbs\Exceptions;
 
-use InvalidArgumentException;
-
-class EventNotValidForCurrentState extends InvalidArgumentException
+class EventNotValidForCurrentState extends EventNotValid
 {
 }

--- a/src/Lifecycle/BrokerConvenienceMethods.php
+++ b/src/Lifecycle/BrokerConvenienceMethods.php
@@ -10,7 +10,6 @@ use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Exceptions\EventNotAuthorized;
 use Thunk\Verbs\Exceptions\EventNotValid;
-use Thunk\Verbs\Exceptions\EventNotValidForCurrentState;
 use Thunk\Verbs\Support\Wormhole;
 
 trait BrokerConvenienceMethods

--- a/src/Lifecycle/BrokerConvenienceMethods.php
+++ b/src/Lifecycle/BrokerConvenienceMethods.php
@@ -8,6 +8,8 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Event;
+use Thunk\Verbs\Exceptions\EventNotAuthorized;
+use Thunk\Verbs\Exceptions\EventNotValid;
 use Thunk\Verbs\Exceptions\EventNotValidForCurrentState;
 use Thunk\Verbs\Support\Wormhole;
 
@@ -49,7 +51,7 @@ trait BrokerConvenienceMethods
             $event->states()->each(fn ($state) => Guards::for($event, $state)->validate());
 
             return true;
-        } catch (EventNotValidForCurrentState) {
+        } catch (EventNotValid|EventNotAuthorized) {
             return false;
         }
     }

--- a/src/Support/PendingEvent.php
+++ b/src/Support/PendingEvent.php
@@ -121,9 +121,9 @@ class PendingEvent
         return $results->count() > 1 ? $results : $results->first();
     }
 
-    public function isAllowed(): bool
+    public function isAuthorized(): bool
     {
-        return app(BrokersEvents::class)->isAllowed($this->event);
+        return app(BrokersEvents::class)->isAuthorized($this->event);
     }
 
     public function isValid(): bool

--- a/tests/Feature/PendingEventChecksTest.php
+++ b/tests/Feature/PendingEventChecksTest.php
@@ -11,7 +11,7 @@ it('can test authorization on a pending event', function () {
         'allowed' => true,
     ]);
 
-    $this->assertTrue($event->isAllowed());
+    $this->assertTrue($event->isAuthorized());
 
     $event = EventWithMultipleStates::make([
         'special_id' => 1,
@@ -19,7 +19,7 @@ it('can test authorization on a pending event', function () {
         'allowed' => false,
     ]);
 
-    $this->assertFalse($event->isAllowed());
+    $this->assertFalse($event->isAuthorized());
 });
 
 it('supports boolean authorization', function () {
@@ -27,13 +27,13 @@ it('supports boolean authorization', function () {
         'allowed' => true,
     ]);
 
-    $this->assertTrue($event->isAllowed());
+    $this->assertTrue($event->isAuthorized());
 
     $event = EventWithBooleanAuth::make([
         'allowed' => false,
     ]);
 
-    $this->assertFalse($event->isAllowed());
+    $this->assertFalse($event->isAuthorized());
 });
 
 it('can test validation on a pending event', function () {


### PR DESCRIPTION
This is just to better match the lifecycle phase names.