### PR TITLE
Introduce ID manager and `Id` facade

### DIFF
--- a/database/migrations/create_verb_snapshots_table.php
+++ b/database/migrations/create_verb_snapshots_table.php
@@ -4,7 +4,6 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Thunk\Verbs\Facades\Id;
-use Thunk\Verbs\Support\IdManager;
 
 return new class extends Migration
 {

--- a/database/migrations/create_verb_snapshots_table.php
+++ b/database/migrations/create_verb_snapshots_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Thunk\Verbs\Support\IdManager;
 
 return new class extends Migration
 {
@@ -11,7 +12,7 @@ return new class extends Migration
         Schema::create('verb_snapshots', function (Blueprint $table) {
             // The 'id' column needs to be set up differently depending
             // on if you're using Snowflakes vs. ULIDs/etc.
-            $this->createConfiguredIdType($table);
+            app(IdManager::class)->createColumnDefinition($table)->primary();
 
             $table->string('type')->index();
             $table->json('data');
@@ -25,17 +26,5 @@ return new class extends Migration
     public function down()
     {
         Schema::dropIfExists('verb_snapshots');
-    }
-
-    protected function createConfiguredIdType(Blueprint $table)
-    {
-        $id_type = strtolower(config('verbs.id_type', 'snowflake'));
-
-        return match ($id_type) {
-            'snowflake' => $table->snowflakeId(),
-            'ulid' => $table->ulid('id')->primary(),
-            'uuid' => $table->uuid('id')->primary(),
-            'default' => throw new UnexpectedValueException("Unknown Verbs ID type: '{$id_type}'"),
-        };
     }
 };

--- a/database/migrations/create_verb_snapshots_table.php
+++ b/database/migrations/create_verb_snapshots_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Thunk\Verbs\Facades\Id;
 use Thunk\Verbs\Support\IdManager;
 
 return new class extends Migration
@@ -12,7 +13,7 @@ return new class extends Migration
         Schema::create('verb_snapshots', function (Blueprint $table) {
             // The 'id' column needs to be set up differently depending
             // on if you're using Snowflakes vs. ULIDs/etc.
-            app(IdManager::class)->createColumnDefinition($table)->primary();
+            Id::createColumnDefinition($table)->primary();
 
             $table->string('type')->index();
             $table->json('data');

--- a/database/migrations/create_verb_state_events_table.php
+++ b/database/migrations/create_verb_state_events_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Thunk\Verbs\Support\IdManager;
 
 return new class extends Migration
 {
@@ -15,7 +16,7 @@ return new class extends Migration
 
             // The 'state_id' column needs to be set up differently depending
             // on if you're using Snowflakes vs. ULIDs/etc.
-            $this->createConfiguredStateIdType($table);
+            app(IdManager::class)->createColumnDefinition($table, 'state_id')->index();
 
             $table->string('state_type')->index();
 
@@ -26,17 +27,5 @@ return new class extends Migration
     public function down()
     {
         Schema::dropIfExists('verb_state_events');
-    }
-
-    protected function createConfiguredStateIdType(Blueprint $table)
-    {
-        $id_type = strtolower(config('verbs.id_type', 'snowflake'));
-
-        return match ($id_type) {
-            'snowflake' => $table->snowflake('state_id')->index(),
-            'ulid' => $table->ulid('state_id')->index(),
-            'uuid' => $table->uuid('state_id')->index(),
-            'default' => throw new UnexpectedValueException("Unknown Verbs ID type: '{$id_type}'"),
-        };
     }
 };

--- a/database/migrations/create_verb_state_events_table.php
+++ b/database/migrations/create_verb_state_events_table.php
@@ -4,7 +4,6 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Thunk\Verbs\Facades\Id;
-use Thunk\Verbs\Support\IdManager;
 
 return new class extends Migration
 {

--- a/database/migrations/create_verb_state_events_table.php
+++ b/database/migrations/create_verb_state_events_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Thunk\Verbs\Facades\Id;
 use Thunk\Verbs\Support\IdManager;
 
 return new class extends Migration
@@ -16,7 +17,7 @@ return new class extends Migration
 
             // The 'state_id' column needs to be set up differently depending
             // on if you're using Snowflakes vs. ULIDs/etc.
-            app(IdManager::class)->createColumnDefinition($table, 'state_id')->index();
+            Id::createColumnDefinition($table, 'state_id')->index();
 
             $table->string('state_type')->index();
 

--- a/src/Facades/Id.php
+++ b/src/Facades/Id.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Thunk\Verbs\Facades;
+
+use Glhd\Bits\Bits;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\ColumnDefinition;
+use Illuminate\Support\Facades\Facade;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Uid\AbstractUid;
+use Thunk\Verbs\Support\IdManager;
+
+/**
+ * @method static int|string|null coerce(Bits|UuidInterface|AbstractUid|int|string|null $id)
+ * @method static int|string coerceOrFail(Bits|UuidInterface|AbstractUid|int|string $id)
+ * @method static int|string make()
+ * @method static ColumnDefinition createColumnDefinition(Blueprint $table, string $name = 'id')
+ */
+class Id extends Facade
+{
+    public static function getFacadeRoot(): IdManager
+    {
+        return parent::getFacadeRoot();
+    }
+
+    protected static function getFacadeAccessor()
+    {
+        return IdManager::class;
+    }
+}

--- a/src/Facades/Id.php
+++ b/src/Facades/Id.php
@@ -11,8 +11,8 @@ use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Support\IdManager;
 
 /**
- * @method static int|string|null coerce(Bits|UuidInterface|AbstractUid|int|string|null $id)
- * @method static int|string coerceOrFail(Bits|UuidInterface|AbstractUid|int|string $id)
+ * @method static int|string|null tryFrom(Bits|UuidInterface|AbstractUid|int|string|null $id)
+ * @method static int|string from(Bits|UuidInterface|AbstractUid|int|string $id)
  * @method static int|string make()
  * @method static ColumnDefinition createColumnDefinition(Blueprint $table, string $name = 'id')
  */

--- a/src/Facades/Verbs.php
+++ b/src/Facades/Verbs.php
@@ -14,7 +14,6 @@ use Thunk\Verbs\Testing\EventStoreFake;
  * @method static bool commit()
  * @method static bool isReplaying()
  * @method static void unlessReplaying(callable $callback)
- * @method static int|string|null toId($id)
  * @method static Event fire(Event $event)
  * @method static void createMetadataUsing(callable $callback)
  * @method static void commitImmediately(bool $commit_immediately = true)

--- a/src/Lifecycle/BrokerConvenienceMethods.php
+++ b/src/Lifecycle/BrokerConvenienceMethods.php
@@ -9,12 +9,19 @@ use Symfony\Component\Uid\AbstractUid;
 use Throwable;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Exceptions\EventNotValidForCurrentState;
+use Thunk\Verbs\Facades\Id;
+use Thunk\Verbs\Support\IdManager;
 use Thunk\Verbs\Support\Wormhole;
 
 trait BrokerConvenienceMethods
 {
     public bool $is_replaying = false;
 
+    /**
+     * @deprecated
+     * @see IdManager
+     * @see Id
+     */
     public function toId(Bits|UuidInterface|AbstractUid|int|string|null $id): int|string|null
     {
         return match (true) {

--- a/src/Lifecycle/EventStore.php
+++ b/src/Lifecycle/EventStore.php
@@ -14,7 +14,6 @@ use Thunk\Verbs\Contracts\StoresEvents;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Exceptions\ConcurrencyException;
 use Thunk\Verbs\Facades\Id;
-use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\Models\VerbEvent;
 use Thunk\Verbs\Models\VerbStateEvent;
 use Thunk\Verbs\State;

--- a/src/Lifecycle/EventStore.php
+++ b/src/Lifecycle/EventStore.php
@@ -60,15 +60,15 @@ class EventStore implements StoresEvents
                 ->with('event')
                 ->unless($singleton, fn (Builder $query) => $query->where('state_id', $state->id))
                 ->where('state_type', $state::class)
-                ->when($after_id, fn (Builder $query) => $query->whereRelation('event', 'id', '>', Id::coerceOrFail($after_id)))
-                ->when($up_to_id, fn (Builder $query) => $query->whereRelation('event', 'id', '<=', Id::coerceOrFail($up_to_id)))
+                ->when($after_id, fn (Builder $query) => $query->whereRelation('event', 'id', '>', Id::from($after_id)))
+                ->when($up_to_id, fn (Builder $query) => $query->whereRelation('event', 'id', '<=', Id::from($up_to_id)))
                 ->lazyById()
                 ->map(fn (VerbStateEvent $pivot) => $pivot->event);
         }
 
         return VerbEvent::query()
-            ->when($after_id, fn (Builder $query) => $query->where('id', '>', Id::coerceOrFail($after_id)))
-            ->when($up_to_id, fn (Builder $query) => $query->where('id', '<=', Id::coerceOrFail($up_to_id)))
+            ->when($after_id, fn (Builder $query) => $query->where('id', '>', Id::from($after_id)))
+            ->when($up_to_id, fn (Builder $query) => $query->where('id', '<=', Id::from($up_to_id)))
             ->lazyById();
     }
 
@@ -128,7 +128,7 @@ class EventStore implements StoresEvents
     protected function formatForWrite(array $event_objects): array
     {
         return array_map(fn (Event $event) => [
-            'id' => Id::coerceOrFail($event->id),
+            'id' => Id::from($event->id),
             'type' => $event::class,
             'data' => app(Serializer::class)->serialize($event),
             'metadata' => app(Serializer::class)->serialize($this->metadata->get($event)),
@@ -143,8 +143,8 @@ class EventStore implements StoresEvents
         return collect($event_objects)
             ->flatMap(fn (Event $event) => $event->states()->map(fn ($state) => [
                 'id' => snowflake_id(),
-                'event_id' => Id::coerceOrFail($event->id),
-                'state_id' => Id::coerceOrFail($state->id),
+                'event_id' => Id::from($event->id),
+                'state_id' => Id::from($state->id),
                 'state_type' => $state::class,
             ]))
             ->all();

--- a/src/Lifecycle/SnapshotStore.php
+++ b/src/Lifecycle/SnapshotStore.php
@@ -7,7 +7,6 @@ use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Exceptions\StateIsNotSingletonException;
 use Thunk\Verbs\Facades\Id;
-use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\Models\VerbSnapshot;
 use Thunk\Verbs\State;
 use Thunk\Verbs\Support\Serializer;

--- a/src/Lifecycle/SnapshotStore.php
+++ b/src/Lifecycle/SnapshotStore.php
@@ -6,6 +6,7 @@ use Glhd\Bits\Bits;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Exceptions\StateIsNotSingletonException;
+use Thunk\Verbs\Facades\Id;
 use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\Models\VerbSnapshot;
 use Thunk\Verbs\State;
@@ -15,7 +16,7 @@ class SnapshotStore
 {
     public function load(Bits|UuidInterface|AbstractUid|int|string $id): ?State
     {
-        $snapshot = VerbSnapshot::find(Verbs::toId($id));
+        $snapshot = VerbSnapshot::find(Id::coerceOrFail($id));
 
         return $snapshot?->state();
     }
@@ -57,10 +58,10 @@ class SnapshotStore
     protected static function formatForWrite(array $states): array
     {
         return array_map(fn (State $state) => [
-            'id' => Verbs::toId($state->id),
+            'id' => Id::coerceOrFail($state->id),
             'type' => $state::class,
             'data' => app(Serializer::class)->serialize($state),
-            'last_event_id' => Verbs::toId($state->last_event_id),
+            'last_event_id' => Id::coerce($state->last_event_id),
             'created_at' => now(),
             'updated_at' => now(),
         ], $states);

--- a/src/Lifecycle/SnapshotStore.php
+++ b/src/Lifecycle/SnapshotStore.php
@@ -15,7 +15,7 @@ class SnapshotStore
 {
     public function load(Bits|UuidInterface|AbstractUid|int|string $id): ?State
     {
-        $snapshot = VerbSnapshot::find(Id::coerceOrFail($id));
+        $snapshot = VerbSnapshot::find(Id::from($id));
 
         return $snapshot?->state();
     }
@@ -57,10 +57,10 @@ class SnapshotStore
     protected static function formatForWrite(array $states): array
     {
         return array_map(fn (State $state) => [
-            'id' => Id::coerceOrFail($state->id),
+            'id' => Id::from($state->id),
             'type' => $state::class,
             'data' => app(Serializer::class)->serialize($state),
-            'last_event_id' => Id::coerce($state->last_event_id),
+            'last_event_id' => Id::tryFrom($state->last_event_id),
             'created_at' => now(),
             'updated_at' => now(),
         ], $states);

--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -9,7 +9,6 @@ use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Contracts\StoresEvents;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Facades\Id;
-use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\State;
 use UnexpectedValueException;
 

--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -37,7 +37,7 @@ class StateManager
     /** @param  class-string<State>  $type */
     public function load(Bits|UuidInterface|AbstractUid|int|string $id, string $type): State
     {
-        $id = Id::coerceOrFail($id);
+        $id = Id::from($id);
         $key = $this->key($id, $type);
 
         // FIXME: If the state we're loading has a last_event_id that's ahead of the registry's last_event_id, we need to re-build the state
@@ -91,7 +91,7 @@ class StateManager
 
     public function setMaxEventId(Bits|UuidInterface|AbstractUid|int|string $max_event_id): static
     {
-        $this->max_event_id = Id::coerceOrFail($max_event_id);
+        $this->max_event_id = Id::from($max_event_id);
 
         return $this;
     }

--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -8,6 +8,7 @@ use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Contracts\StoresEvents;
 use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Id;
 use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\State;
 use UnexpectedValueException;
@@ -37,7 +38,7 @@ class StateManager
     /** @param  class-string<State>  $type */
     public function load(Bits|UuidInterface|AbstractUid|int|string $id, string $type): State
     {
-        $id = Verbs::toId($id);
+        $id = Id::coerceOrFail($id);
         $key = $this->key($id, $type);
 
         // FIXME: If the state we're loading has a last_event_id that's ahead of the registry's last_event_id, we need to re-build the state
@@ -91,7 +92,7 @@ class StateManager
 
     public function setMaxEventId(Bits|UuidInterface|AbstractUid|int|string $max_event_id): static
     {
-        $this->max_event_id = Verbs::toId($max_event_id);
+        $this->max_event_id = Id::coerceOrFail($max_event_id);
 
         return $this;
     }

--- a/src/Support/IdManager.php
+++ b/src/Support/IdManager.php
@@ -26,7 +26,7 @@ class IdManager
         }
     }
 
-    public function coerce(Bits|UuidInterface|AbstractUid|int|string|null $id): int|string|null
+    public function tryFrom(Bits|UuidInterface|AbstractUid|int|string|null $id): int|string|null
     {
         return match (true) {
             $id instanceof Bits => $id->id(),
@@ -36,9 +36,9 @@ class IdManager
         };
     }
 
-    public function coerceOrFail(Bits|UuidInterface|AbstractUid|int|string $id): int|string
+    public function from(Bits|UuidInterface|AbstractUid|int|string $id): int|string
     {
-        $coerced = $this->coerce($id);
+        $coerced = $this->tryFrom($id);
 
         if (is_int($coerced) || is_string($coerced)) {
             return $coerced;

--- a/src/Support/IdManager.php
+++ b/src/Support/IdManager.php
@@ -26,7 +26,7 @@ class IdManager
         }
     }
 
-    public function toId(Bits|UuidInterface|AbstractUid|int|string|null $id): int|string|null
+    public function coerce(Bits|UuidInterface|AbstractUid|int|string|null $id): int|string|null
     {
         return match (true) {
             $id instanceof Bits => $id->id(),
@@ -36,9 +36,9 @@ class IdManager
         };
     }
 
-    public function toIdOrFail(Bits|UuidInterface|AbstractUid|int|string $id): int|string
+    public function coerceOrFail(Bits|UuidInterface|AbstractUid|int|string $id): int|string
     {
-        $coerced = $this->toId($id);
+        $coerced = $this->coerce($id);
 
         if (is_int($coerced) || is_string($coerced)) {
             return $coerced;

--- a/src/Support/IdManager.php
+++ b/src/Support/IdManager.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Thunk\Verbs\Support;
+
+use Glhd\Bits\Bits;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\ColumnDefinition;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Uid\AbstractUid;
+
+class IdManager
+{
+    public const TYPE_SNOWFLAKE = 'snowflake';
+
+    public const TYPE_ULID = 'ulid';
+
+    public const TYPE_UUID = 'uuid';
+
+    public function __construct(
+        protected string $id_type
+    ) {
+        if (! in_array($this->id_type, [self::TYPE_SNOWFLAKE, self::TYPE_ULID, self::TYPE_UUID])) {
+            throw new InvalidArgumentException("'{$this->id_type}' is not a valid verbs.id_type");
+        }
+    }
+
+    public function toId(Bits|UuidInterface|AbstractUid|int|string|null $id): int|string|null
+    {
+        return match (true) {
+            $id instanceof Bits => $id->id(),
+            $id instanceof UuidInterface => $id->toString(),
+            $id instanceof AbstractUid => (string) $id,
+            default => $id,
+        };
+    }
+
+    public function toIdOrFail(Bits|UuidInterface|AbstractUid|int|string $id): int|string
+    {
+        $coerced = $this->toId($id);
+
+        if (is_int($coerced) || is_string($coerced)) {
+            return $coerced;
+        }
+
+        throw new InvalidArgumentException(get_debug_type($id).' cannot be cast to a valid ID.');
+    }
+
+    public function make(): int|string
+    {
+        return match ($this->id_type) {
+            self::TYPE_SNOWFLAKE => snowflake_id(),
+            self::TYPE_ULID => Str::ulid(),
+            self::TYPE_UUID => Str::orderedUuid(),
+        };
+    }
+
+    public function createColumnDefinition(Blueprint $table, string $name = 'id'): ColumnDefinition
+    {
+        return match ($this->id_type) {
+            self::TYPE_SNOWFLAKE => $table->snowflake($name),
+            self::TYPE_ULID => $table->ulid($name),
+            self::TYPE_UUID => $table->uuid($name),
+        };
+    }
+}

--- a/src/Testing/EventStoreFake.php
+++ b/src/Testing/EventStoreFake.php
@@ -38,10 +38,10 @@ class EventStoreFake implements StoresEvents
         return LazyCollection::make($this->events)
             ->flatten()
             ->when($after_id, function (LazyCollection $events, $after_id) {
-                return $events->filter(fn (Event $event) => $event->id > Id::coerceOrFail($after_id));
+                return $events->filter(fn (Event $event) => $event->id > Id::from($after_id));
             })
             ->when($up_to_id, function (LazyCollection $events, $up_to_id) {
-                return $events->filter(fn (Event $event) => $event->id <= Id::coerceOrFail($up_to_id));
+                return $events->filter(fn (Event $event) => $event->id <= Id::from($up_to_id));
             })
             ->when($state, function (LazyCollection $events, State $state) use ($singleton) {
                 return $singleton

--- a/src/Testing/EventStoreFake.php
+++ b/src/Testing/EventStoreFake.php
@@ -13,7 +13,6 @@ use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Contracts\StoresEvents;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Facades\Id;
-use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\Lifecycle\MetadataManager;
 use Thunk\Verbs\State;
 

--- a/src/Testing/EventStoreFake.php
+++ b/src/Testing/EventStoreFake.php
@@ -12,6 +12,7 @@ use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Contracts\StoresEvents;
 use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Id;
 use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\Lifecycle\MetadataManager;
 use Thunk\Verbs\State;
@@ -38,10 +39,10 @@ class EventStoreFake implements StoresEvents
         return LazyCollection::make($this->events)
             ->flatten()
             ->when($after_id, function (LazyCollection $events, $after_id) {
-                return $events->filter(fn (Event $event) => $event->id > Verbs::toId($after_id));
+                return $events->filter(fn (Event $event) => $event->id > Id::coerceOrFail($after_id));
             })
             ->when($up_to_id, function (LazyCollection $events, $up_to_id) {
-                return $events->filter(fn (Event $event) => $event->id <= Verbs::toId($up_to_id));
+                return $events->filter(fn (Event $event) => $event->id <= Id::coerceOrFail($up_to_id));
             })
             ->when($state, function (LazyCollection $events, State $state) use ($singleton) {
                 return $singleton

--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -29,6 +29,7 @@ use Thunk\Verbs\Lifecycle\SnapshotStore;
 use Thunk\Verbs\Lifecycle\StateManager;
 use Thunk\Verbs\Livewire\SupportVerbs;
 use Thunk\Verbs\Support\EventStateRegistry;
+use Thunk\Verbs\Support\IdManager;
 use Thunk\Verbs\Support\Serializer;
 use Thunk\Verbs\Support\Wormhole;
 
@@ -66,6 +67,12 @@ class VerbsServiceProvider extends PackageServiceProvider
         $this->app->singleton(EventStateRegistry::class);
         $this->app->singleton(MetadataManager::class);
         $this->app->singleton(Serializer::class);
+
+        $this->app->singleton(IdManager::class, function (Container $app) {
+            return new IdManager(
+                id_type: $app->make(Repository::class)->get('verbs.id_type', 'snowflake'),
+            );
+        });
 
         $this->app->singleton(Wormhole::class, function (Container $app) {
             $config = $app->make(Repository::class);


### PR DESCRIPTION
Because Verbs needs to handle Snowflakes, ULIDs, and UUIDs, we need to coerce values into an `int` or `string` regularly as well as generate new IDs of the selected type. This moves all that logic into a new `IdManager` class, and also introduces an `Id` facade.