### PR TITLE
Change snapshots to be found by ID and type

### DIFF
--- a/database/migrations/create_verb_snapshots_table.php
+++ b/database/migrations/create_verb_snapshots_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
         Schema::create('verb_snapshots', function (Blueprint $table) {
             // The 'id' column needs to be set up differently depending
             // on if you're using Snowflakes vs. ULIDs/etc.
-            Id::createColumnDefinition($table)->primary();
+            $idColumn = Id::createColumnDefinition($table)->primary();
 
             $table->string('type')->index();
             $table->json('data');
@@ -20,6 +20,8 @@ return new class extends Migration
             $table->snowflake('last_event_id')->nullable();
 
             $table->timestamps();
+
+            $table->unique([$idColumn->get('name', 'id'), 'type']);
         });
     }
 

--- a/src/Lifecycle/SnapshotStore.php
+++ b/src/Lifecycle/SnapshotStore.php
@@ -13,9 +13,9 @@ use Thunk\Verbs\Support\Serializer;
 
 class SnapshotStore
 {
-    public function load(Bits|UuidInterface|AbstractUid|int|string $id): ?State
+    public function load(Bits|UuidInterface|AbstractUid|int|string $id, string $type): ?State
     {
-        $snapshot = VerbSnapshot::find(Id::from($id));
+        $snapshot = VerbSnapshot::whereKey(Id::from($id))->whereType($type)->first();
 
         return $snapshot?->state();
     }

--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -46,7 +46,7 @@ class StateManager
             return $state;
         }
 
-        if ($state = $this->snapshots->load($id)) {
+        if ($state = $this->snapshots->load($id, $type)) {
             if (! $state instanceof $type) {
                 throw new UnexpectedValueException(sprintf('Expected State <%d> to be of type "%s" but got "%s"', $id, class_basename($type), class_basename($state)));
             }

--- a/tests/Feature/NestedEventsTest.php
+++ b/tests/Feature/NestedEventsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+use Thunk\Verbs\Models\VerbEvent;
+use Thunk\Verbs\State;
+
+it('does not load the incorrect state in a nested fired event', function () {
+    SubscriptionAdded::fire(
+        organisation_id: '1',
+        provider: 'stripe',
+        source_order_line_item_id: '5',
+    );
+
+    Verbs::commit();
+
+    expect($events = VerbEvent::all())
+        ->toHaveCount(2)
+        ->and($events[0])
+        ->type->toBe(SubscriptionAdded::class)
+        ->and($events[1])
+        ->type->toBe(GrantAccountCredit::class);
+});
+
+class SubscriptionAdded extends Event
+{
+    #[StateId(SubscriptionState::class)]
+    public string $organisation_id;
+
+    public function apply(SubscriptionState $state): void
+    {
+        $state->is_first_subscription = is_null($state->is_first_subscription);
+    }
+
+    public function handle()
+    {
+        GrantAccountCredit::fire(
+            organisation_id: $this->organisation_id,
+            credit_amount_cents: 50000
+        );
+    }
+}
+
+class SubscriptionState extends State
+{
+    public ?bool $is_first_subscription = null;
+}
+
+class GrantAccountCredit extends Event
+{
+    public const SIGNUP_BONUS_CENTS = 50000;
+
+    public function __construct(
+        #[StateId(AccountCreditState::class)]
+        public string $organisation_id,
+        public int $credit_amount_cents,
+    ) {}
+
+    public function apply(AccountCreditState $state): void
+    {
+        $state->balance_in_cents += $this->credit_amount_cents;
+    }
+}
+
+class AccountCreditState extends State
+{
+    public int $balance_in_cents = 0;
+}

--- a/tests/Feature/NestedEventsTest.php
+++ b/tests/Feature/NestedEventsTest.php
@@ -55,7 +55,8 @@ class GrantAccountCredit extends Event
         #[StateId(AccountCreditState::class)]
         public string $organisation_id,
         public int $credit_amount_cents,
-    ) {}
+    ) {
+    }
 
     public function apply(AccountCreditState $state): void
     {

--- a/tests/Feature/NestedEventsTest.php
+++ b/tests/Feature/NestedEventsTest.php
@@ -49,8 +49,6 @@ class SubscriptionState extends State
 
 class GrantAccountCredit extends Event
 {
-    public const SIGNUP_BONUS_CENTS = 50000;
-
     public function __construct(
         #[StateId(AccountCreditState::class)]
         public string $organisation_id,


### PR DESCRIPTION
So the problem originally submitted in this failing test was due to having the same ID for both the `SubscriptionState` and the `AccountCreditState`.

The reason for this was states we're being found by the ID only, so it was just finding the first one in the database with that ID. Hence why it was throwing a type mismatch error.

This PR changes states so they can be found using ID and type combination.

I've added a `unique()` index to the migration linking ID and type and updated the SnapshotStore load method to accept ID and type.

I don't think this is a breaking change, but some users may be missing the new index if they don't republish the migrations.

Hope this helps!

PS. the failing test is a `ReplayCommandTest` which is also failing on `main` so is unrelated to the changes in this PR.

---

**Original issue:**

See this Discord discusssion for details https://discord.com/channels/1176581731168567366/1209286927400833044/1209287950953742377

For some reason it is trying to load the `SubscriptionState` inside the `GrantAccountCredit` event when it should be loading `AccountCreditState`.

<img width="1080" alt="image" src="https://github.com/hirethunk/verbs/assets/882837/4191908e-af2a-4115-834c-7c2a72247ea0">
