### PR TITLE
Add the ability to use a custom event on a statefactory

### DIFF
--- a/src/StateFactory.php
+++ b/src/StateFactory.php
@@ -44,6 +44,7 @@ class StateFactory
         protected int|string|null $id = null,
         protected bool $singleton = false,
         protected ?Generator $faker = null,
+        protected string $initial_event = VerbsStateInitialized::class,
     ) {
     }
 
@@ -120,7 +121,7 @@ class StateFactory
     /** @return TStateType */
     protected function createState(): State
     {
-        $initialized = VerbsStateInitialized::fire(
+        $initialized = $this->initial_event::fire(
             state_id: $this->id ?? Id::make(),
             state_class: $this->state_class,
             state_data: $this->getRawData(),


### PR DESCRIPTION
This allows for 

```php
class UserFactory extends StateFactory
{
    protected $initial_event = UserCreated::class;

    public function definition()
    {
        return ['name' => $this->faker->name];
    }
}
```

To fire `UserCreated` instead of `VerbsStateInitialized`