### PR TITLE
Make Verbs Table Name Configurable

### DIFF
--- a/config/verbs.php
+++ b/config/verbs.php
@@ -57,16 +57,13 @@ return [
     |--------------------------------------------------------------------------
     |
     | By default, Verbs prefixes all of its table names with "verb_". However, you
-    | may wish to customized these table names to better fit your application.
-    | You can do so here. Just be sure to update your migrations accordingly.
-    | If you have not yet run the verbs migrations, then we will will use these
-    | values when creating the verbs tables.
+    | may wish to customize these table names to better fit your application.
     |
     */
     'tables' => [
-        'verb_events' => 'verb_events',
-        'verb_snapshots' => 'verb_snapshots',
-        'verb_state_events' => 'verb_state_events',
+        'events' => 'verb_events',
+        'snapshots' => 'verb_snapshots',
+        'state_events' => 'verb_state_events',
     ],
 
     /*

--- a/config/verbs.php
+++ b/config/verbs.php
@@ -53,6 +53,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Table Names
+    |--------------------------------------------------------------------------
+    |
+    | By default, Verbs prefixes all of its table names with "verb_". However, you
+    | may wish to customized these table names to better fit your application.
+    | You can do so here. Just be sure to update your migrations accordingly.
+    | If you have not yet run the verbs migrations, then we will will use these
+    | values when creating the verbs tables.
+    |
+    */
+    'tables' => [
+        'verb_events' => 'verb_events',
+        'verb_snapshots' => 'verb_snapshots',
+        'verb_state_events' => 'verb_state_events',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Wormhole
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/create_verb_events_table.php
+++ b/database/migrations/create_verb_events_table.php
@@ -8,7 +8,9 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create(config('verbs.tables.verb_events'), function (Blueprint $table) {
+        $table = config('verbs.tables.events', 'verb_events');
+
+        Schema::create($table, function (Blueprint $table) {
             $table->snowflakeId();
 
             $table->string('type')->index();
@@ -21,6 +23,6 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::dropIfExists(config('verbs.tables.verb_events'));
+        Schema::dropIfExists(config('verbs.tables.events', 'verb_events'));
     }
 };

--- a/database/migrations/create_verb_events_table.php
+++ b/database/migrations/create_verb_events_table.php
@@ -8,9 +8,7 @@ return new class extends Migration
 {
     public function up()
     {
-        $table = config('verbs.tables.events', 'verb_events');
-
-        Schema::create($table, function (Blueprint $table) {
+        Schema::create($this->tableName(), function (Blueprint $table) {
             $table->snowflakeId();
 
             $table->string('type')->index();
@@ -23,6 +21,11 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::dropIfExists(config('verbs.tables.events', 'verb_events'));
+        Schema::dropIfExists($this->tableName());
+    }
+
+    protected function tableName(): string
+    {
+        return config('verbs.tables.events', 'verb_events');
     }
 };

--- a/database/migrations/create_verb_events_table.php
+++ b/database/migrations/create_verb_events_table.php
@@ -8,7 +8,7 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create('verb_events', function (Blueprint $table) {
+        Schema::create(config('verbs.tables.verb_events'), function (Blueprint $table) {
             $table->snowflakeId();
 
             $table->string('type')->index();
@@ -21,6 +21,6 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('verb_events');
+        Schema::dropIfExists(config('verbs.tables.verb_events'));
     }
 };

--- a/database/migrations/create_verb_snapshots_table.php
+++ b/database/migrations/create_verb_snapshots_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create('verb_snapshots', function (Blueprint $table) {
+        Schema::create(config('verbs.tables.verb_snapshots'), function (Blueprint $table) {
             // The 'id' column needs to be set up differently depending
             // on if you're using Snowflakes vs. ULIDs/etc.
             $idColumn = Id::createColumnDefinition($table)->primary();
@@ -27,6 +27,6 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('verb_snapshots');
+        Schema::dropIfExists(config('verbs.tables.verb_snapshots'));
     }
 };

--- a/database/migrations/create_verb_snapshots_table.php
+++ b/database/migrations/create_verb_snapshots_table.php
@@ -9,9 +9,7 @@ return new class extends Migration
 {
     public function up()
     {
-        $table = config('verbs.tables.snapshots', 'verb_snapshots');
-
-        Schema::create($table, function (Blueprint $table) {
+        Schema::create($this->tableName(), function (Blueprint $table) {
             // The 'id' column needs to be set up differently depending
             // on if you're using Snowflakes vs. ULIDs/etc.
             $idColumn = Id::createColumnDefinition($table)->primary();
@@ -29,6 +27,11 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::dropIfExists(config('verbs.tables.snapshots', 'verb_snapshots'));
+        Schema::dropIfExists($this->tableName());
+    }
+
+    protected function tableName(): string
+    {
+        return config('verbs.tables.snapshots', 'verb_snapshots');
     }
 };

--- a/database/migrations/create_verb_snapshots_table.php
+++ b/database/migrations/create_verb_snapshots_table.php
@@ -9,7 +9,9 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create(config('verbs.tables.verb_snapshots'), function (Blueprint $table) {
+        $table = config('verbs.tables.snapshots', 'verb_snapshots');
+
+        Schema::create($table, function (Blueprint $table) {
             // The 'id' column needs to be set up differently depending
             // on if you're using Snowflakes vs. ULIDs/etc.
             $idColumn = Id::createColumnDefinition($table)->primary();
@@ -27,6 +29,6 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::dropIfExists(config('verbs.tables.verb_snapshots'));
+        Schema::dropIfExists(config('verbs.tables.snapshots', 'verb_snapshots'));
     }
 };

--- a/database/migrations/create_verb_state_events_table.php
+++ b/database/migrations/create_verb_state_events_table.php
@@ -9,9 +9,7 @@ return new class extends Migration
 {
     public function up()
     {
-        $table = config('verbs.tables.state_events', 'verb_state_events');
-
-        Schema::create($table, function (Blueprint $table) {
+        Schema::create($this->tableName(), function (Blueprint $table) {
             $table->snowflakeId();
 
             $table->snowflake('event_id')->index();
@@ -28,6 +26,11 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::dropIfExists(config('verbs.tables.state_events', 'verb_state_events'));
+        Schema::dropIfExists($this->tableName());
+    }
+
+    protected function tableName(): string
+    {
+        return config('verbs.tables.state_events', 'verb_state_events');
     }
 };

--- a/database/migrations/create_verb_state_events_table.php
+++ b/database/migrations/create_verb_state_events_table.php
@@ -9,7 +9,9 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create(config('verbs.tables.verb_state_events'), function (Blueprint $table) {
+        $table = config('verbs.tables.state_events', 'verb_state_events');
+
+        Schema::create($table, function (Blueprint $table) {
             $table->snowflakeId();
 
             $table->snowflake('event_id')->index();
@@ -26,6 +28,6 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::dropIfExists(config('verbs.tables.verb_state_events'));
+        Schema::dropIfExists(config('verbs.tables.state_events', 'verb_state_events'));
     }
 };

--- a/database/migrations/create_verb_state_events_table.php
+++ b/database/migrations/create_verb_state_events_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create('verb_state_events', function (Blueprint $table) {
+        Schema::create(config('verbs.tables.verb_state_events'), function (Blueprint $table) {
             $table->snowflakeId();
 
             $table->snowflake('event_id')->index();
@@ -26,6 +26,6 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('verb_state_events');
+        Schema::dropIfExists(config('verbs.tables.verb_state_events'));
     }
 };

--- a/src/Models/VerbEvent.php
+++ b/src/Models/VerbEvent.php
@@ -30,7 +30,12 @@ class VerbEvent extends Model
 
     public function setTable($table): void
     {
-        $this->table = config('verbs.tables.verb_events');
+        $this->table = $this->getTable();
+    }
+
+    public function getTable()
+    {
+        return config('verbs.tables.verb_events');
     }
 
     public function event(): Event

--- a/src/Models/VerbEvent.php
+++ b/src/Models/VerbEvent.php
@@ -28,7 +28,7 @@ class VerbEvent extends Model
 
     protected ?Metadata $meta = null;
 
-    public function setTable(): void
+    public function setTable($table): void
     {
         $this->table = config('verbs.tables.verb_events');
     }

--- a/src/Models/VerbEvent.php
+++ b/src/Models/VerbEvent.php
@@ -12,8 +12,6 @@ use Thunk\Verbs\Support\Serializer;
 
 class VerbEvent extends Model
 {
-    public $table = 'verb_events';
-
     public $guarded = [];
 
     protected $casts = [
@@ -29,6 +27,11 @@ class VerbEvent extends Model
     protected ?Event $event = null;
 
     protected ?Metadata $meta = null;
+
+    protected function setTable(): void
+    {
+        $this->table = config('verbs.tables.verb_events');
+    }
 
     public function event(): Event
     {

--- a/src/Models/VerbEvent.php
+++ b/src/Models/VerbEvent.php
@@ -28,9 +28,9 @@ class VerbEvent extends Model
 
     protected ?Metadata $meta = null;
 
-    public function setTable($table = null): void
+    public function getTable()
     {
-        $this->table = config('verbs.tables.verb_events');
+        return $this->table ?? config('verbs.tables.events', 'verb_events');
     }
 
     public function event(): Event

--- a/src/Models/VerbEvent.php
+++ b/src/Models/VerbEvent.php
@@ -28,7 +28,7 @@ class VerbEvent extends Model
 
     protected ?Metadata $meta = null;
 
-    protected function setTable(): void
+    public function setTable(): void
     {
         $this->table = config('verbs.tables.verb_events');
     }

--- a/src/Models/VerbEvent.php
+++ b/src/Models/VerbEvent.php
@@ -28,14 +28,9 @@ class VerbEvent extends Model
 
     protected ?Metadata $meta = null;
 
-    public function setTable($table): void
+    public function setTable($table = null): void
     {
-        $this->table = $this->getTable();
-    }
-
-    public function getTable()
-    {
-        return config('verbs.tables.verb_events');
+        $this->table = config('verbs.tables.verb_events');
     }
 
     public function event(): Event

--- a/src/Models/VerbSnapshot.php
+++ b/src/Models/VerbSnapshot.php
@@ -17,11 +17,14 @@ use UnexpectedValueException;
  */
 class VerbSnapshot extends Model
 {
-    public $table = 'verb_snapshots';
-
     public $guarded = [];
 
     protected ?State $state = null;
+
+    protected function setTable(): void
+    {
+        $this->table = config('verbs.tables.verb_snapshots');
+    }
 
     public function state(): State
     {

--- a/src/Models/VerbSnapshot.php
+++ b/src/Models/VerbSnapshot.php
@@ -23,7 +23,12 @@ class VerbSnapshot extends Model
 
     public function setTable($table): void
     {
-        $this->table = config('verbs.tables.verb_snapshots');
+        $this->table = $this->getTable();
+    }
+
+    public function getTable()
+    {
+        return config('verbs.tables.verb_snapshots');
     }
 
     public function state(): State

--- a/src/Models/VerbSnapshot.php
+++ b/src/Models/VerbSnapshot.php
@@ -21,7 +21,7 @@ class VerbSnapshot extends Model
 
     protected ?State $state = null;
 
-    public function setTable(): void
+    public function setTable($table): void
     {
         $this->table = config('verbs.tables.verb_snapshots');
     }

--- a/src/Models/VerbSnapshot.php
+++ b/src/Models/VerbSnapshot.php
@@ -21,9 +21,9 @@ class VerbSnapshot extends Model
 
     protected ?State $state = null;
 
-    public function setTable($table = null): void
+    public function getTable()
     {
-        $this->table = config('verbs.tables.verb_snapshots');
+        return $this->table ?? config('verbs.tables.snapshots', 'verb_snapshots');
     }
 
     public function state(): State

--- a/src/Models/VerbSnapshot.php
+++ b/src/Models/VerbSnapshot.php
@@ -21,7 +21,7 @@ class VerbSnapshot extends Model
 
     protected ?State $state = null;
 
-    protected function setTable(): void
+    public function setTable(): void
     {
         $this->table = config('verbs.tables.verb_snapshots');
     }

--- a/src/Models/VerbSnapshot.php
+++ b/src/Models/VerbSnapshot.php
@@ -21,14 +21,9 @@ class VerbSnapshot extends Model
 
     protected ?State $state = null;
 
-    public function setTable($table): void
+    public function setTable($table = null): void
     {
-        $this->table = $this->getTable();
-    }
-
-    public function getTable()
-    {
-        return config('verbs.tables.verb_snapshots');
+        $this->table = config('verbs.tables.verb_snapshots');
     }
 
     public function state(): State

--- a/src/Models/VerbStateEvent.php
+++ b/src/Models/VerbStateEvent.php
@@ -7,9 +7,12 @@ use Thunk\Verbs\State;
 
 class VerbStateEvent extends Model
 {
-    public $table = 'verb_state_events';
-
     public $guarded = [];
+
+    protected function setTable(): void
+    {
+        $this->table = config('verbs.tables.verb_state_events');
+    }
 
     public function event()
     {

--- a/src/Models/VerbStateEvent.php
+++ b/src/Models/VerbStateEvent.php
@@ -9,14 +9,9 @@ class VerbStateEvent extends Model
 {
     public $guarded = [];
 
-    public function setTable($table): void
+    public function setTable($table = null): void
     {
-        $this->table = $this->getTable();
-    }
-
-    public function getTable()
-    {
-        return config('verbs.tables.verb_state_events');
+        $this->table = config('verbs.tables.verb_state_events');
     }
 
     public function event()

--- a/src/Models/VerbStateEvent.php
+++ b/src/Models/VerbStateEvent.php
@@ -9,9 +9,9 @@ class VerbStateEvent extends Model
 {
     public $guarded = [];
 
-    public function setTable($table = null): void
+    public function getTable()
     {
-        $this->table = config('verbs.tables.verb_state_events');
+        return $this->table ?? config('verbs.tables.state_events', 'verb_state_events');
     }
 
     public function event()

--- a/src/Models/VerbStateEvent.php
+++ b/src/Models/VerbStateEvent.php
@@ -11,7 +11,12 @@ class VerbStateEvent extends Model
 
     public function setTable($table): void
     {
-        $this->table = config('verbs.tables.verb_state_events');
+        $this->table = $this->getTable();
+    }
+
+    public function getTable()
+    {
+        return config('verbs.tables.verb_state_events');
     }
 
     public function event()

--- a/src/Models/VerbStateEvent.php
+++ b/src/Models/VerbStateEvent.php
@@ -9,7 +9,7 @@ class VerbStateEvent extends Model
 {
     public $guarded = [];
 
-    protected function setTable(): void
+    public function setTable(): void
     {
         $this->table = config('verbs.tables.verb_state_events');
     }

--- a/src/Models/VerbStateEvent.php
+++ b/src/Models/VerbStateEvent.php
@@ -9,7 +9,7 @@ class VerbStateEvent extends Model
 {
     public $guarded = [];
 
-    public function setTable(): void
+    public function setTable($table): void
     {
         $this->table = config('verbs.tables.verb_state_events');
     }

--- a/tests/Unit/ConfigurableTableNamesTest.php
+++ b/tests/Unit/ConfigurableTableNamesTest.php
@@ -23,7 +23,7 @@ test('VerbSnapshot table name can be configured', function () {
 });
 
 test('VerbStateEvent table name can be configured', function () {
-    $expected_table_name = 'verb_snapshots';
+    $expected_table_name = 'verb_state_events';
 
     $verb_model = new VerbStateEvent();
     $actual_table_name = $verb_model->getTable();

--- a/tests/Unit/ConfigurableTableNamesTest.php
+++ b/tests/Unit/ConfigurableTableNamesTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Config;
 use Thunk\Verbs\Models\VerbEvent;
 use Thunk\Verbs\Models\VerbSnapshot;
 use Thunk\Verbs\Models\VerbStateEvent;
@@ -17,10 +16,9 @@ test('VerbEvent table name can be configured', function () {
 test('VerbEvent table name can be configured with different table name', function () {
     $expected_table_name = 'sys_verb_events';
 
-    config()->set('verbs.tables.verb_events', $expected_table_name);
+    config()->set('verbs.tables.events', $expected_table_name);
 
     $verb_model = new VerbEvent();
-    $verb_model->setTable();
     $actual_table_name = $verb_model->getTable();
 
     expect($expected_table_name)->toBe($actual_table_name);
@@ -38,10 +36,9 @@ test('VerbSnapshot table name can be configured', function () {
 test('VerbSnapshot table name can be configured with different table name', function () {
     $expected_table_name = 'sys_verb_snapshots';
 
-    config(['verbs.tables.verb_snapshots' => $expected_table_name]);
+    config(['verbs.tables.snapshots' => $expected_table_name]);
 
     $verb_model = new VerbSnapshot();
-    $verb_model->setTable();
     $actual_table_name = $verb_model->getTable();
 
     expect($expected_table_name)->toBe($actual_table_name);
@@ -59,10 +56,9 @@ test('VerbStateEvent table name can be configured', function () {
 test('VerbStateEvent table name can be configured with different table name', function () {
     $expected_table_name = 'sys_verb_state_events';
 
-    config(['verbs.tables.verb_state_events' => $expected_table_name]);
+    config(['verbs.tables.state_events' => $expected_table_name]);
 
     $verb_model = new VerbStateEvent();
-    $verb_model->setTable();
     $actual_table_name = $verb_model->getTable();
 
     expect($expected_table_name)->toBe($actual_table_name);

--- a/tests/Unit/ConfigurableTableNamesTest.php
+++ b/tests/Unit/ConfigurableTableNamesTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Thunk\Verbs\Models\VerbEvent;
+use Thunk\Verbs\Models\VerbSnapshot;
+use Thunk\Verbs\Models\VerbStateEvent;
+
+test('VerbEvent table name can be configured', function () {
+    $expected_table_name = 'verb_events';
+
+    $verb_model = new VerbEvent();
+    $actual_table_name = $verb_model->getTable();
+
+    expect($expected_table_name)->toBe($actual_table_name);
+});
+
+test('VerbSnapshot table name can be configured', function () {
+    $expected_table_name = 'verb_snapshots';
+
+    $verb_model = new VerbSnapshot();
+    $actual_table_name = $verb_model->getTable();
+
+    expect($expected_table_name)->toBe($actual_table_name);
+});
+
+test('VerbStateEvent table name can be configured', function () {
+    $expected_table_name = 'verb_snapshots';
+
+    $verb_model = new VerbStateEvent();
+    $actual_table_name = $verb_model->getTable();
+
+    expect($expected_table_name)->toBe($actual_table_name);
+});

--- a/tests/Unit/ConfigurableTableNamesTest.php
+++ b/tests/Unit/ConfigurableTableNamesTest.php
@@ -1,11 +1,23 @@
 <?php
 
+use Illuminate\Support\Facades\Config;
 use Thunk\Verbs\Models\VerbEvent;
 use Thunk\Verbs\Models\VerbSnapshot;
 use Thunk\Verbs\Models\VerbStateEvent;
 
 test('VerbEvent table name can be configured', function () {
     $expected_table_name = 'verb_events';
+
+    $verb_model = new VerbEvent();
+    $actual_table_name = $verb_model->getTable();
+
+    expect($expected_table_name)->toBe($actual_table_name);
+});
+
+test('VerbEvent table name can be configured with different table name', function () {
+    $expected_table_name = 'sys_verb_events';
+
+    config()->set('verbs.tables.verb_events', $expected_table_name);
 
     $verb_model = new VerbEvent();
     $actual_table_name = $verb_model->getTable();
@@ -22,8 +34,30 @@ test('VerbSnapshot table name can be configured', function () {
     expect($expected_table_name)->toBe($actual_table_name);
 });
 
+test('VerbSnapshot table name can be configured with different table name', function () {
+    $expected_table_name = 'sys_verb_snapshots';
+
+    config(['verbs.tables.verb_snapshots' => $expected_table_name]);
+
+    $verb_model = new VerbSnapshot();
+    $actual_table_name = $verb_model->getTable();
+
+    expect($expected_table_name)->toBe($actual_table_name);
+});
+
 test('VerbStateEvent table name can be configured', function () {
     $expected_table_name = 'verb_state_events';
+
+    $verb_model = new VerbStateEvent();
+    $actual_table_name = $verb_model->getTable();
+
+    expect($expected_table_name)->toBe($actual_table_name);
+});
+
+test('VerbStateEvent table name can be configured with different table name', function () {
+    $expected_table_name = 'sys_verb_state_events';
+
+    config(['verbs.tables.verb_state_events' => $expected_table_name]);
 
     $verb_model = new VerbStateEvent();
     $actual_table_name = $verb_model->getTable();

--- a/tests/Unit/ConfigurableTableNamesTest.php
+++ b/tests/Unit/ConfigurableTableNamesTest.php
@@ -20,6 +20,7 @@ test('VerbEvent table name can be configured with different table name', functio
     config()->set('verbs.tables.verb_events', $expected_table_name);
 
     $verb_model = new VerbEvent();
+    $verb_model->setTable();
     $actual_table_name = $verb_model->getTable();
 
     expect($expected_table_name)->toBe($actual_table_name);
@@ -40,6 +41,7 @@ test('VerbSnapshot table name can be configured with different table name', func
     config(['verbs.tables.verb_snapshots' => $expected_table_name]);
 
     $verb_model = new VerbSnapshot();
+    $verb_model->setTable();
     $actual_table_name = $verb_model->getTable();
 
     expect($expected_table_name)->toBe($actual_table_name);
@@ -60,6 +62,7 @@ test('VerbStateEvent table name can be configured with different table name', fu
     config(['verbs.tables.verb_state_events' => $expected_table_name]);
 
     $verb_model = new VerbStateEvent();
+    $verb_model->setTable();
     $actual_table_name = $verb_model->getTable();
 
     expect($expected_table_name)->toBe($actual_table_name);


### PR DESCRIPTION
The PR introduces the ability to configure the table names used by Verbs. The idea behind this is that some people wish to prefix their table names based on which part of the system the table belongs to or change the database table name entirely.