### PR TITLE
Auto-commit after each job is processed

### DIFF
--- a/tests/Feature/AutoCommitTest.php
+++ b/tests/Feature/AutoCommitTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+
+it('auto-commits after a job is processed', function () {
+    Verbs::fake();
+
+    Verbs::assertNothingCommitted();
+
+    dispatch(function () {
+        AutoCommitTestEvent::fire(message: 'auto-commit test');
+    });
+
+    Verbs::assertCommitted(function (AutoCommitTestEvent $event) {
+        return $event->message === 'auto-commit test';
+    });
+});
+
+class AutoCommitTestEvent extends Event
+{
+    public function __construct(public string $message)
+    {
+    }
+}

--- a/tests/Unit/AppliesToStateTest.php
+++ b/tests/Unit/AppliesToStateTest.php
@@ -26,7 +26,8 @@ class ContactRequestAcknowledged extends Event
 {
     public function __construct(
         public int $contact_request_id
-    ) {}
+    ) {
+    }
 
     public function apply(ContactRequestState $state)
     {


### PR DESCRIPTION
This improves our auto-commit logic to also run after each job on the queue has been processed.