### PR TITLE
Update glhd/bits for Laravel 11 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "glhd/bits": "^0.4",
+        "glhd/bits": "^0.4|^0.3",
         "illuminate/contracts": "^10.0|^11.0",
         "internachi/modular": "^2.0",
         "laravel/prompts": "^0.1.15",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "glhd/bits": "^0.3.0",
+        "glhd/bits": "^0.3",
         "illuminate/contracts": "^10.0|^11.0",
         "internachi/modular": "^2.0",
         "laravel/prompts": "^0.1.15",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "glhd/bits": "^0.3",
+        "glhd/bits": "^0.4",
         "illuminate/contracts": "^10.0|^11.0",
         "internachi/modular": "^2.0",
         "laravel/prompts": "^0.1.15",


### PR DESCRIPTION
# Changes

* sets `glhd/bits` dependency to `^0.4|^0.3` to allow the correct version.

# Why

Without this any install of Laravel 11 will fail because it needs to install `glhd/bits` 0.3 as it's own dependency but 0.3 is only compatible with Laravel 10.