### PR TITLE
Auto-commit on DB transaction

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -10,7 +10,7 @@ php artisan verbs:event CustomerBeganTrial
 
 When you create your first event, it will generate in a fresh `app/Events` directory.
 
-A brand new event file will look like this:
+A brand-new event file will look like this:
 
 ```php
 class MyEvent extends Event
@@ -49,18 +49,25 @@ public string $player_id;
 
 ### Committing
 
-After you call `fire()`, Verbs will then call `Verbs::commit()` _for you_, persisting the event.
+When you `fire()` an event, it gets pushed to an in-memory queue to be saved with all other Verbs events
+that you fire. Think of this kind-of like staging changes in git. Events are eventually “committed” in a
+single database `insert`. You can usually let Verbs handle this for you, but may also manually commit
+your events by calling `Verbs::commit()`.
 
-Events are queued as PendingEvents until the `commit()` happens, where they all get committed in a single database request.
+`Verbs::commit()` is automatically called:
 
-Here's when a `commit()` occurs:
-- at the end of every request (after returning a response)
+- at the end of every request (before returning a response)
 - at the end of every console command
 - at the end of every queued job
+- immediately before a database transaction is committed
 
-In [tests](testing), you'll need to call `Verbs::commit()` manually.
+In [tests](testing), you'll often need to call `Verbs::commit()` manually unless your test triggers
+one of the above.
 
-You can call `MyEvent::commit()` as well (instead of `fire()`), which will both fire AND commit an event (and all events in the queue), which is useful when you need to return the result of an event, such as a store method on a controller.
+You can also call `Event::commit()` (instead of `fire()`), which will both fire AND commit the event 
+(and all events in the queue). `Event::commit()` also returns whatever your event’s `handle()` method
+returns, which is useful when you need to immediately use the result of an event, such as a store 
+method on a controller.
 
 ```php
 // CustomerBeganTrial event

--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -4,6 +4,7 @@ namespace Thunk\Verbs;
 
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Database\Events\TransactionCommitting;
 use Illuminate\Events\Dispatcher as LaravelDispatcher;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Support\DateFactory;
@@ -144,8 +145,8 @@ class VerbsServiceProvider extends PackageServiceProvider
             $this->app->make(BrokersEvents::class)->fire($event);
         }
 
-        // Auto-commit after each job on the queue is processed
-        if ($event instanceof JobProcessed) {
+        // Auto-commit after each job on the queue is processed, and before any DB transactions commit
+        if ($event instanceof JobProcessed || $event instanceof TransactionCommitting) {
             app(BrokersEvents::class)->commit();
         }
     }

--- a/tests/Feature/AutoCommitTest.php
+++ b/tests/Feature/AutoCommitTest.php
@@ -9,11 +9,23 @@ it('auto-commits after a job is processed', function () {
     Verbs::assertNothingCommitted();
 
     dispatch(function () {
-        AutoCommitTestEvent::fire(message: 'auto-commit test');
+        AutoCommitTestEvent::fire(message: 'auto-commit job test');
     });
 
     Verbs::assertCommitted(function (AutoCommitTestEvent $event) {
-        return $event->message === 'auto-commit test';
+        return $event->message === 'auto-commit job test';
+    });
+});
+
+it('auto-commits before a DB transaction commits', function () {
+    Verbs::fake();
+
+    Verbs::assertNothingCommitted();
+
+    DB::transaction(fn () => AutoCommitTestEvent::fire(message: 'auto-commit db test'));
+
+    Verbs::assertCommitted(function (AutoCommitTestEvent $event) {
+        return $event->message === 'auto-commit db test';
     });
 });
 


### PR DESCRIPTION
If you fire Verbs events during a database transaction, you want those events to commit to the DB inside that transaction. This PR makes Verbs auto-commit on the `TransactionCommitting` event.