### PR TITLE
Allow injecting multiple states into `handle()`

### DIFF
--- a/src/Lifecycle/Hook.php
+++ b/src/Lifecycle/Hook.php
@@ -154,7 +154,7 @@ class Hook
 
                 // FIXME: We need to throw an ambiguous state exception if a method wants a state that we have 2+ of
                 //        But right now, we'll just null them out
-                if (isset($parameters[$state::class])) {
+                if (array_key_exists($state::class, $parameters)) {
                     $state = null;
                 }
 
@@ -162,9 +162,12 @@ class Hook
                     $parameters[$key] = $state;
                 }
             }
+
+            foreach ($states->aliasNames() as $alias) {
+                $parameters[$alias] = $states->get($alias);
+            }
         }
 
-        // We're going to null out any parameters that may be ambiguous, so we need to filter them here
-        return array_filter($parameters);
+        return $parameters;
     }
 }

--- a/src/Support/StateCollection.php
+++ b/src/Support/StateCollection.php
@@ -28,6 +28,11 @@ class StateCollection extends Collection
         return $this;
     }
 
+    public function aliasNames(): array
+    {
+        return array_keys($this->aliases);
+    }
+
     public function get($key, $default = null)
     {
         if (! $this->has($key) && isset($this->aliases[$key])) {

--- a/tests/Feature/DependencyInjectionTest.php
+++ b/tests/Feature/DependencyInjectionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+use Thunk\Verbs\State;
+
+it('can injects states as expected', function () {
+    Verbs::fake();
+    $event = DependencyInjectionTestEvent::fire();
+    Verbs::commit();
+    expect($event->expectations)->toBeEmpty();
+});
+
+it('can inject states of same type into event handle methods by alias', function () {
+    Verbs::fake();
+    DependencyInjectionTestMultiHandleEvent::commit();
+});
+
+class DependencyInjectionTestEvent extends Event
+{
+    public array $expectations = [
+        'test1_validate',
+        'test2_validate',
+        'test1_apply',
+        'test2_apply',
+        'test1_handle',
+        'test2_handle',
+    ];
+
+    public function __construct(
+        #[StateId(DependencyInjectionTestState::class)] public ?int $test1_id,
+        #[StateId(DependencyInjectionTestSecondState::class)] public ?int $test2_id,
+    ) {
+    }
+
+    public function validate1(DependencyInjectionTestState $state)
+    {
+        unset($this->expectations[array_search('test1_validate', $this->expectations)]);
+    }
+
+    public function validate2(DependencyInjectionTestSecondState $state)
+    {
+        unset($this->expectations[array_search('test2_validate', $this->expectations)]);
+    }
+
+    public function apply1(DependencyInjectionTestState $state)
+    {
+        unset($this->expectations[array_search('test1_apply', $this->expectations)]);
+    }
+
+    public function apply2(DependencyInjectionTestSecondState $state)
+    {
+        unset($this->expectations[array_search('test2_apply', $this->expectations)]);
+    }
+
+    public function handle(DependencyInjectionTestState $test1, DependencyInjectionTestSecondState $test2)
+    {
+        unset($this->expectations[array_search('test1_handle', $this->expectations)]);
+        unset($this->expectations[array_search('test2_handle', $this->expectations)]);
+    }
+}
+
+class DependencyInjectionTestMultiHandleEvent extends Event
+{
+    public function __construct(
+        #[StateId(DependencyInjectionTestState::class)] public ?int $test1_id,
+        #[StateId(DependencyInjectionTestState::class)] public ?int $test2_id,
+    ) {
+    }
+
+    public function apply(DependencyInjectionTestState $state)
+    {
+        if ($state->id === $this->test1_id) {
+            $state->name = 'test1';
+        }
+        if ($state->id === $this->test2_id) {
+            $state->name = 'test2';
+        }
+    }
+
+    public function handle(DependencyInjectionTestState $test1, DependencyInjectionTestState $test2)
+    {
+        expect($test1->name)->toBe('test1')
+            ->and($test2->name)->toBe('test2');
+    }
+}
+
+class DependencyInjectionTestState extends State
+{
+    public ?string $name;
+}
+
+class DependencyInjectionTestSecondState extends State
+{
+    public ?string $name;
+}


### PR DESCRIPTION
Right now if you're dealing with multiple state objects of the same type, you need to access them via `$this->states()->get($alias)` which is cumbersome. This PR lets you inject the states by alias name:

```php
class DemoState extends State
{
  public function __construct(
    #[StateId(UserState::class)] $user1_id,
    #[StateId(UserState::class)] $user2_id,
  ) {}
  
  public function handle(UserState $user1, UserState $user2)
  {
    $this->assert($user1->id === $this->user1_id);
    $this->assert($user2->id === $this->user2_id);
  }
}
```