### PR TITLE
Remove `__verbs_initialized`

### DIFF
--- a/src/Events/VerbsStateInitialized.php
+++ b/src/Events/VerbsStateInitialized.php
@@ -29,7 +29,7 @@ class VerbsStateInitialized extends Event implements CommitsImmediately
     public function validate()
     {
         $this->assert(
-            ! $this->state()->__verbs_initialized,
+            $this->state()->last_event_id === null,
             'State has already been initialized',
         );
     }
@@ -41,7 +41,5 @@ class VerbsStateInitialized extends Event implements CommitsImmediately
         foreach ($this->state_data as $key => $value) {
             $state->$key = $value;
         }
-
-        $state->__verbs_initialized = true;
     }
 }

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -60,7 +60,6 @@ class Broker implements BrokersEvents
 
         app(StateManager::class)->writeSnapshots();
 
-
         foreach ($events as $event) {
             $this->metadata->setLastResults($event, $this->dispatcher->handle($event, $event->states()));
         }

--- a/src/State.php
+++ b/src/State.php
@@ -19,9 +19,6 @@ abstract class State implements UrlRoutable
 
     public Bits|UuidInterface|AbstractUid|int|string|null $last_event_id = null;
 
-    // TODO: This should move to state metadata eventually
-    public bool $__verbs_initialized = false;
-
     public function __construct()
     {
         app(StateManager::class)->register($this);

--- a/tests/Unit/StateManagerTest.php
+++ b/tests/Unit/StateManagerTest.php
@@ -5,7 +5,6 @@ use Thunk\Verbs\Contracts\StoresSnapshots;
 use Thunk\Verbs\Exceptions\StateNotFoundException;
 use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\Lifecycle\MetadataManager;
-use Thunk\Verbs\Models\VerbSnapshot;
 use Thunk\Verbs\State;
 use Thunk\Verbs\Testing\EventStoreFake;
 use Thunk\Verbs\Testing\SnapshotStoreFake;


### PR DESCRIPTION
This drops the `__verbs_initialized` property in favor of just checking if `last_event_id` is `null`. It's one less magic property to deal with.