### PR TITLE
[BUG] Empty state snapshots being stored

### DIFF
--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -52,13 +52,14 @@ class Broker implements BrokersEvents
     {
         $events = app(EventQueue::class)->flush();
 
+        if (empty($events)) {
+            return true;
+        }
+
         // FIXME: Only write changes + handle aggregate versioning
 
         app(StateManager::class)->writeSnapshots();
 
-        if (empty($events)) {
-            return true;
-        }
 
         foreach ($events as $event) {
             $this->metadata->setLastResults($event, $this->dispatcher->handle($event, $event->states()));

--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -81,7 +81,12 @@ class StateManager
 
     public function writeSnapshots(): bool
     {
-        return $this->snapshots->write($this->states->values()->all());
+        return $this->snapshots->write(
+            $this->states
+                ->reject(fn(State $state) => $state->last_event_id === null)
+                ->values()
+                ->all()
+        );
     }
 
     public function setReplaying(bool $replaying): static

--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -81,12 +81,7 @@ class StateManager
 
     public function writeSnapshots(): bool
     {
-        return $this->snapshots->write(
-            $this->states
-                ->reject(fn(State $state) => $state->last_event_id === null)
-                ->values()
-                ->all()
-        );
+        return $this->snapshots->write($this->states->values()->all());
     }
 
     public function setReplaying(bool $replaying): static

--- a/src/Testing/SnapshotStoreFake.php
+++ b/src/Testing/SnapshotStoreFake.php
@@ -21,6 +21,11 @@ class SnapshotStoreFake implements StoresSnapshots
     /** @var Collection<int, Collection<int, State>> */
     protected Collection $states;
 
+    public function __construct()
+    {
+        $this->states = new Collection();
+    }
+
     public function write(array $states): bool
     {
         foreach ($states as $state) {

--- a/tests/Unit/StateManagerTest.php
+++ b/tests/Unit/StateManagerTest.php
@@ -1,18 +1,20 @@
 <?php
 
+use Thunk\Verbs\Contracts\StoresEvents;
+use Thunk\Verbs\Contracts\StoresSnapshots;
 use Thunk\Verbs\Exceptions\StateNotFoundException;
-use Thunk\Verbs\Lifecycle\Dispatcher;
+use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\Lifecycle\MetadataManager;
-use Thunk\Verbs\Lifecycle\StateManager;
+use Thunk\Verbs\Models\VerbSnapshot;
 use Thunk\Verbs\State;
 use Thunk\Verbs\Testing\EventStoreFake;
 use Thunk\Verbs\Testing\SnapshotStoreFake;
 
-beforeEach(fn () => app()->instance(StateManager::class, new StateManager(
-    dispatcher: app(Dispatcher::class),
-    snapshots: new SnapshotStoreFake(),
-    events: new EventStoreFake(app(MetadataManager::class)),
-)));
+beforeEach(function () {
+    app()->instance(StoresSnapshots::class, new SnapshotStoreFake());
+    app()->instance(StoresEvents::class, new EventStoreFake(app(MetadataManager::class)));
+}
+);
 
 test('loadOrFail triggers an exception if state does not exist', function () {
     StateManagerTestState::loadOrFail(1);
@@ -22,6 +24,13 @@ test('load does not trigger an exception if state does not exist', function () {
     expect(StateManagerTestState::load(1))
         ->toBeInstanceOf(StateManagerTestState::class)
         ->last_event_id->toBeNull();
+});
+
+test('snapshots are not stored for states that have no events', function () {
+    StateManagerTestState::load(1);
+    Verbs::commit();
+
+    app(StoresSnapshots::class)->assertNothingWritten();
 });
 
 class StateManagerTestState extends State


### PR DESCRIPTION
When using the new route model binding updates for state classes, I discovered that snapshots were being stored in the database for 404 requests.