### PR TITLE
Add support for `symfony/serializer` v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "internachi/modular": "^2.0",
         "laravel/prompts": "^0.1.15",
         "spatie/laravel-package-tools": "^1.14.0",
-        "symfony/property-access": "^7.0",
-        "symfony/serializer": "^7.0"
+        "symfony/property-access": "^6.2|^7.0",
+        "symfony/serializer": "^6.3|^7.0"
     },
     "require-dev": {
         "brick/money": "^0.8.1",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "internachi/modular": "^2.0",
         "laravel/prompts": "^0.1.15",
         "spatie/laravel-package-tools": "^1.14.0",
-        "symfony/property-access": "^6.2",
-        "symfony/serializer": "^6.3"
+        "symfony/property-access": "^7.0",
+        "symfony/serializer": "^7.0"
     },
     "require-dev": {
         "brick/money": "^0.8.1",

--- a/examples/Monopoly/src/Support/MoneyNormalizer.php
+++ b/examples/Monopoly/src/Support/MoneyNormalizer.php
@@ -9,7 +9,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class MoneyNormalizer implements DenormalizerInterface, NormalizerInterface
 {
-    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return is_a($type, Money::class, true);
     }
@@ -20,7 +20,7 @@ class MoneyNormalizer implements DenormalizerInterface, NormalizerInterface
         return Money::ofMinor($data['amount'], $data['currency']);
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof Money;
     }

--- a/src/Support/Normalization/AcceptsNormalizerAndDenormalizer.php
+++ b/src/Support/Normalization/AcceptsNormalizerAndDenormalizer.php
@@ -11,7 +11,7 @@ trait AcceptsNormalizerAndDenormalizer
 {
     protected NormalizerInterface|DenormalizerInterface $serializer;
 
-    public function setSerializer(SerializerInterface $serializer)
+    public function setSerializer(SerializerInterface $serializer): void
     {
         if ($serializer instanceof NormalizerInterface && $serializer instanceof DenormalizerInterface) {
             $this->serializer = $serializer;

--- a/src/Support/Normalization/BitsNormalizer.php
+++ b/src/Support/Normalization/BitsNormalizer.php
@@ -9,7 +9,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class BitsNormalizer implements DenormalizerInterface, NormalizerInterface
 {
-    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return is_a($type, Bits::class, true);
     }
@@ -20,7 +20,7 @@ class BitsNormalizer implements DenormalizerInterface, NormalizerInterface
         return $type::coerce($data);
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof Bits;
     }

--- a/src/Support/Normalization/CarbonNormalizer.php
+++ b/src/Support/Normalization/CarbonNormalizer.php
@@ -10,7 +10,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class CarbonNormalizer implements DenormalizerInterface, NormalizerInterface
 {
-    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return is_a($type, CarbonInterface::class, true);
     }
@@ -23,7 +23,7 @@ class CarbonNormalizer implements DenormalizerInterface, NormalizerInterface
             : $type::parse($data);
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof CarbonInterface;
     }

--- a/src/Support/Normalization/CollectionNormalizer.php
+++ b/src/Support/Normalization/CollectionNormalizer.php
@@ -14,7 +14,7 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
 {
     use AcceptsNormalizerAndDenormalizer;
 
-    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return is_a($type, Collection::class, true);
     }
@@ -40,7 +40,7 @@ class CollectionNormalizer implements DenormalizerInterface, NormalizerInterface
             ->map(fn ($value) => $this->serializer->denormalize($value, $subtype, $format, $context));
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof Collection;
     }

--- a/src/Support/Normalization/ModelNormalizer.php
+++ b/src/Support/Normalization/ModelNormalizer.php
@@ -22,7 +22,7 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface
         static::$allow_normalization = $allow_normalization;
     }
 
-    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $this->typeSupportsModelIdentifiers($type) && $this->isDenormalizedModelIdentifier($data);
     }
@@ -43,7 +43,7 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface
         return $this->getRestoredPropertyValue($identifier);
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof QueueableEntity
             || $data instanceof QueueableCollection;

--- a/src/Support/Normalization/SelfSerializingNormalizer.php
+++ b/src/Support/Normalization/SelfSerializingNormalizer.php
@@ -12,7 +12,7 @@ class SelfSerializingNormalizer implements DenormalizerInterface, NormalizerInte
 {
     use AcceptsNormalizerAndDenormalizer;
 
-    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return is_a($type, SerializedByVerbs::class, true);
     }
@@ -31,7 +31,7 @@ class SelfSerializingNormalizer implements DenormalizerInterface, NormalizerInte
         return $type::deserializeForVerbs($data, $this->serializer);
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof SerializedByVerbs;
     }

--- a/src/Support/Normalization/StateNormalizer.php
+++ b/src/Support/Normalization/StateNormalizer.php
@@ -11,7 +11,7 @@ use Thunk\Verbs\Support\Serializer;
 
 class StateNormalizer implements DenormalizerInterface, NormalizerInterface
 {
-    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return is_a($type, State::class, true) && is_numeric($data);
     }
@@ -22,7 +22,7 @@ class StateNormalizer implements DenormalizerInterface, NormalizerInterface
         return app(StateManager::class)->load((int) $data, $type);
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof State
             && $data !== app(Serializer::class)->active_normalization_target;


### PR DESCRIPTION
to fix #104 

v7 of symfony/serializer is available and causes the install of verbs to fail.