### PR TITLE
Docs updates

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -112,18 +112,18 @@ class ChildState extends State
 
 Now that `ParentState` has a record of our `ChildState`, we can load the child *through* the parent with `AppliesToChildState`.
 
-Let's show this by firing a `ChildActionedThroughParent` event with our new attribute:
+Let's show this by firing a `NestedStateAccessed` event with our new attribute:
 
 ```php
-ChildActionedThroughParent::fire(parent_id: 1);
+NestedStateAccessed::fire(parent_id: 1);
 
-// ChildActionedThroughParent.php
+// NestedStateAccessed.php
 #[AppliesToChildState(
     state_type: ChildState::class,
     parent_type: ParentState::class,
     id: 'child_id'
 )]
-class ChildActionedThroughParent extends Event
+class NestedStateAccessed extends Event
 {
     #[StateId(ParentState::class)]
     public int $parent_id;

--- a/docs/combating-jargon.md
+++ b/docs/combating-jargon.md
@@ -30,14 +30,14 @@ a `cancelled_at` timestamp to the `Account` model.
 Reactors are similar to projectors, but they're meant for one-time side effects like sending
 mail or making external API requests (things that you wouldn't want to happen again if you
 ever replay your events). In Verbs, there is no formal concept of Reactors. Instead, you can
-just wrap code that you only want to run once inside of a `Verbs::unlessReplaying()` check.
+just wrap code that you only want to run once inside of a [`Verbs::unlessReplaying()`](/docs/reference/events/) check.
 
 ## Write Models and Read Models + CQRS
 
 CQRS stands for "Command Query Responsibility Segregation" and is a pattern where writes (commands)
-and reads (queries) are kept separate. Improved scalability and performance are often cited as 
+and reads (queries) are kept separate. Improved scalability and performance are often cited as
 reasons to introduce CQRS, but the real benefit for even small applications is the flexibility
 that it allows. Developers often have to make concessions in their data models to account for both
 read and write concerns. With event sourcing and separate read and write models, you can build
-Eloquent (read) models that are 100% custom-tailored to your application UI and access patterns, 
+Eloquent (read) models that are 100% custom-tailored to your application UI and access patterns,
 and create new data through events (writes) that map exactly to _what happened_ in your application.

--- a/docs/events.md
+++ b/docs/events.md
@@ -64,9 +64,9 @@ your events by calling `Verbs::commit()`.
 In [tests](testing), you'll often need to call `Verbs::commit()` manually unless your test triggers
 one of the above.
 
-You can also call `Event::commit()` (instead of `fire()`), which will both fire AND commit the event 
+You can also call `Event::commit()` (instead of `fire()`), which will both fire AND commit the event
 (and all events in the queue). `Event::commit()` also returns whatever your event’s `handle()` method
-returns, which is useful when you need to immediately use the result of an event, such as a store 
+returns, which is useful when you need to immediately use the result of an event, such as a store
 method on a controller.
 
 ```php
@@ -139,7 +139,7 @@ public function apply(CountState $state)
 CountState::load($id)->count; // 2
 ```
 
-The `fired()` hook executes in memory after the event fires, but before it's stored in the database. This allows your [state](/docs/reference/states) to take care of any changes from your first event, and allows you to use the updated state in your next event. In our next example, we'll illustrate this.
+The `fired()` hook executes in memory after the event fires, but before it's stored in the database. This allows your state to take care of any changes from your first event, and allows you to use the updated state in your next event. In our next example, we'll illustrate this.
 
 Let's say we have a game where a level 4 Player levels up and receives a reward.
 
@@ -215,9 +215,9 @@ Truncate all the data that is created by your event handlers. If you don't, you 
 
 #### One-time effects
 
-You'll want to tell verbs when effects should NOT trigger on replay (like sending a welcome email).
+You'll want to tell verbs when effects should NOT trigger on replay (like sending a welcome email). You may use:
 
-You may use `unlessReplaying`:
+##### `Verbs::unlessReplaying()`
 
 ```php
 Verbs::unlessReplaying(function () {
@@ -229,7 +229,7 @@ Or the `#[Once]` [attribute](/docs/technical/attributes#content-once).
 
 ### Firing during Replays
 
-During a [replay](#content-replaying-events), the system isn't "firing" the event in the original sense (i.e., it's not going through the initial logic that might include checks, validations, or triggering of additional side effects like sending one-time-notifications). Instead, it directly applies the changes recorded in the event store.
+During a [replay](#content-replaying-events), the system isn't "firing" the event in the original sense (i.e., it's not going through the initial logic that might include checks, validations, or triggering of additional side effects like sending one-time notifications). Instead, it directly applies the changes recorded in the event store.
 
 
 ### Wormholes

--- a/docs/ids.md
+++ b/docs/ids.md
@@ -32,7 +32,7 @@ By setting your event's `state_id` property to null--
 class CustomerBeganTrial extends Event
 {
     #[StateId(CustomerState::class)]
-    public ?int $customer_id =  null;
+    public ?int $customer_id = null;
 }
 ```
 

--- a/docs/ids.md
+++ b/docs/ids.md
@@ -22,3 +22,26 @@ class JobApplication extends Model
     use HasSnowflakes; // Add this to your model
 }
 ```
+
+### Automatically generate snowflake ids
+
+Verbs allows for `snowflake_id` auto-generation by default when using most of our [attributes](/docs/technical/attributes).
+By setting your event's `state_id` property to null--
+
+```php
+class CustomerBeganTrial extends Event
+{
+    #[StateId(CustomerState::class)]
+    public ?int $customer_id =  null;
+}
+```
+
+--and setting no id value when you fire your event, you allow Verbs' `autofill` default to provide a `snowflake_id()` *for you*.
+
+```php
+    $event = CustomerBeganTrial::fire() // no set customer_id
+
+    $event->customer_id; // = snowflake_id()
+```
+
+If you wish to disable autofill for some reason, you may set it to `false` in your attributes.

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -5,6 +5,6 @@ This takes all the **public** properties on your objects and converts them to JS
 
 Verbs ships with a number of default normalizers that should be perfect for the typical Laravel
 application. If you need to store more complex data, you may need to add your own normalizers,
-which you can do in the Verbs config file. You can change the
+which you can do in `config/verbs.php` file. You may also change the
 [default serializer context](https://symfony.com/doc/current/components/serializer.html#context)
-in the Verbs config file as well.
+there as well.

--- a/docs/state-first-development.md
+++ b/docs/state-first-development.md
@@ -34,3 +34,23 @@ public function handle()
 ```
 
 Because we've told our state to care about this property, we can keep track of all the changes there, grab the calculation output right from the state, and send it to our database.
+
+## Don't mix Models and States
+
+In general, mixing Eloquent models with your event data can have unintended consequences,
+especially when it comes to [replaying events](/docs/reference/events#content-replaying-events). For example, imagine that you fire an event that creates
+a model, and then store that model's ID in a subsequent event. If you ever replay your events,
+the resulting model may have a different auto-incremented ID, and so your later event will
+unintentionally reference the wrong model.
+
+You can mitigate this issue by always using Snowflakes or ULIDs across your entire app, but
+it's still generally a bad idea. Because of this, Verbs will trigger an exception if you
+ever try to store a reference to a model inside your events or states.
+
+If you **really know what you're doing**, you can disable this behavior with:
+
+```php
+Thunk\Verbs\Support\Normalization\ModelNormalizer::dangerouslyAllowModelNormalization();
+```
+
+As the method name suggests, this is not recommended and may have unintended consequences.

--- a/docs/states.md
+++ b/docs/states.md
@@ -82,6 +82,8 @@ public function applyToGameState(GameState $state) {}
 public function applyToPlayerState(PlayerState $state) {}
 ```
 
+On [`fire()`](/docs/reference/events#content-firing-events), Verbs will find and call all relevant state and event methods prefixed with "apply".
+
 ### Validating Event data using your State
 
 It's possible to use your state to determine whether or not you want to fire your event in the first place.

--- a/docs/states.md
+++ b/docs/states.md
@@ -120,8 +120,7 @@ You can also use `loadOrFail()` to trigger a `StateNotFoundException` that will 
 
 ## Using States in Routes
 
-States implement Laravel’s `UrlRoutable` interface, which means you can route to them in the exact same 
-way you would do [route-model binding](https://laravel.com/docs/11.x/routing#route-model-binding):
+States implement Laravel’s `UrlRoutable` interface, which means you can route to them in the exact same way you would do [route-model binding](https://laravel.com/docs/11.x/routing#route-model-binding):
 
 ```php
 Route::get('/users/{user_state}', function(UserState $user_state) {
@@ -237,7 +236,7 @@ class FooCreated class
     public function handle()
     {
         Foo::create(
-            snowflake: $this->id
+            snowflake: $this->foo_id
         );
     }
 }

--- a/src/Exceptions/DoNotStoreModelsOnEventsOrStates.php
+++ b/src/Exceptions/DoNotStoreModelsOnEventsOrStates.php
@@ -12,7 +12,7 @@ class DoNotStoreModelsOnEventsOrStates extends RuntimeException
     {
         $type = class_basename($object);
 
-        $docs_url = 'https://verbs.thunk.dev/docs/crash-course/state-vs-model#content-dont-mix-models-and-states';
+        $docs_url = 'https://verbs.thunk.dev/docs/techniques/state-first-development#content-dont-mix-models-and-states';
 
         parent::__construct("You are trying to store a '{$type}' in your Verbs event data. This is probably not what you want to do! See: <{$docs_url}>");
     }


### PR DESCRIPTION
attributes.md
- fixed typo (thanks @madebycaliper!)
- added params breakdown for each Autodiscovery attribute
- added example of nested states

events.md
- made `unlessReplaying` more prominent by making `Verbs::unlessReplaying` a header
- linking to this in combating-jargon.md

ids.md
- added section explaining snowflake autofill
- linking to this in attributes.md

state-first-development.md
- restored the section on mixing models and states, `dangerouslyAllowModelNormalization();`
- updated `src/Exceptions/DoNotStoreModelsOnEventsOrStates.php` to point to this section

states.md
- addressed methods prefixed with "apply"

And small misc updates of links, spacing, grammar, inconsistent or redundant terms, and an incorrect prop in a code example.