### PR TITLE
Queue events before calling fired hooks

### DIFF
--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -37,9 +37,9 @@ class Broker implements BrokersEvents
 
         $states->each(fn ($state) => $this->dispatcher->apply($event, $state));
 
-        $this->dispatcher->fired($event, $states);
-
         app(Queue::class)->queue($event);
+
+        $this->dispatcher->fired($event, $states);
 
         if ($this->commit_immediately || $event instanceof CommitsImmediately) {
             $this->commit();


### PR DESCRIPTION
Right now we're calling `fired` before an event gets pushed to the queue. This means that dependent events can be queued in the wrong order.