### PR TITLE
Add On Attribute

### DIFF
--- a/src/Attributes/Hooks/On.php
+++ b/src/Attributes/Hooks/On.php
@@ -11,7 +11,8 @@ class On implements HookAttribute
 {
     public function __construct(
         public Phase $phase
-    ) { }
+    ) {
+    }
 
     public function applyToHook(Hook $hook): void
     {

--- a/src/Attributes/Hooks/On.php
+++ b/src/Attributes/Hooks/On.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Thunk\Verbs\Attributes\Hooks;
+
+use Attribute;
+use Thunk\Verbs\Lifecycle\Hook;
+use Thunk\Verbs\Lifecycle\Phase;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class On implements HookAttribute
+{
+    public function __construct(
+        public Phase $phase
+    ) { }
+
+    public function applyToHook(Hook $hook): void
+    {
+        $hook->forcePhases($this->phase);
+    }
+}


### PR DESCRIPTION
Adds an `On()` attribute that can be used to specify which phase an external listener should fire in

Example:

```php
class FooListener
{
    #[On(Phase::Handle)]
    public function doFooThing(FooThingDone $event)
    {
        //
    }
}
```