### PR TITLE
Fix disable autofill issue

### DIFF
--- a/src/Support/EventStateRegistry.php
+++ b/src/Support/EventStateRegistry.php
@@ -55,7 +55,7 @@ class EventStateRegistry
 
         $discovered->push(...$states);
 
-        if (count($states) > 0 &&  $alias = $attribute->getAlias()) {
+        if (count($states) > 0 && $alias = $attribute->getAlias()) {
             if (count($states) > 1) {
                 throw new InvalidArgumentException('You cannot provide an alias for an array of states.');
             }

--- a/src/Support/EventStateRegistry.php
+++ b/src/Support/EventStateRegistry.php
@@ -55,7 +55,7 @@ class EventStateRegistry
 
         $discovered->push(...$states);
 
-        if ($alias = $attribute->getAlias()) {
+        if (count($states) > 0 &&  $alias = $attribute->getAlias()) {
             if (count($states) > 1) {
                 throw new InvalidArgumentException('You cannot provide an alias for an array of states.');
             }

--- a/tests/Unit/StateIdTest.php
+++ b/tests/Unit/StateIdTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+use Thunk\Verbs\State;
+
+it('can find the state ID property', function () {
+    $id = snowflake_id();
+
+    StateIdTestEvent::commit(
+        state_id: $id
+    );
+
+    $state = StateIdTestState::load($id);
+
+    $this->assertTrue($state->acknowledged);
+});
+
+it('can disable autofill for a state ID property and still load state if ID is supplied', function () {
+    $id = snowflake_id();
+    $other_id = snowflake_id();
+
+    $event = StateIdTestEvent::fire(
+        state_id: $id,
+        other_state_id: $other_id,
+    );
+
+    Verbs::commit();
+
+    expect($event->states())
+        ->toHaveCount(2)
+        ->get(0)->id->toBe($id)
+        ->get(0)->acknowledged->toBe(true)
+        ->get(1)->id->toBe($other_id)
+        ->get(1)->acknowledged->toBe(true);
+});
+
+it('can disable autofill for a state ID property allowing it to be set to null', function () {
+    $id = snowflake_id();
+
+    $event = StateIdTestEvent::fire(
+        state_id: $id,
+        other_state_id: null,
+    );
+
+    Verbs::commit();
+
+    expect($event->states())
+        ->toHaveCount(1)
+        ->get(0)->id->toBe($id)
+        ->get(0)->acknowledged->toBe(true);
+});
+
+class StateIdTestState extends State
+{
+    public bool $acknowledged = false;
+}
+
+class StateIdTestEvent extends Event
+{
+    #[StateId(StateIdTestState::class)]
+    public int $state_id;
+
+    #[StateId(StateIdTestState::class, autofill: false)]
+    public ?int $other_state_id = null;
+
+    public function apply(StateIdTestState $state)
+    {
+        $state->acknowledged = true;
+    }
+}


### PR DESCRIPTION
## The scenario

Currently if you have a property that has a `StateId` set to `null`, Verbs will generate an ID for it.

But there are some scenarios where a property should actually be set to `null` and no new ID/ state should get generated for it, as it's an optional reference to another state.

To solve this, we can use the `autofill: false` property on the `StateId` attribute.

```php
#[StateId(StateIdTestState::class, autofill: false)]
public ?int $other_state_id = null;
```

## The problem

The problem is that at the moment, doing the above code throws the following error:

<img width="1002" alt="image" src="https://github.com/hirethunk/verbs/assets/882837/07c23c16-5587-42c3-91e1-a69aad16f7cc">

## The solution

This PR fixes it by ensuring that when the `EventStateRegistry` discovers states, that it has actually found a state before trying to process the aliases.

I couldn't see any unit tests for `StateId` so I have added a basic test and added 2 tests that cover the `autofill: false` scenarios.