### PR TITLE
Use the PhpDocExtractor in addition to the ReflectionExtractor.

### DIFF
--- a/config/verbs.php
+++ b/config/verbs.php
@@ -1,5 +1,6 @@
 <?php
 
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
@@ -42,6 +43,7 @@ return [
     'normalizers' => [
         SelfSerializingNormalizer::class,
         CollectionNormalizer::class,
+        ArrayDenormalizer::class,
         ModelNormalizer::class,
         StateNormalizer::class,
         BitsNormalizer::class,

--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -9,7 +9,9 @@ use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Support\DateFactory;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
@@ -107,7 +109,11 @@ class VerbsServiceProvider extends PackageServiceProvider
                 : new AnnotationLoader;
 
             return new PropertyNormalizer(
-                propertyTypeExtractor: new ReflectionExtractor,
+                propertyTypeExtractor: new PropertyInfoExtractor(
+                    typeExtractors: [
+                        new PhpDocExtractor,
+                        new ReflectionExtractor,
+                    ]),
                 classDiscriminatorResolver: new ClassDiscriminatorFromClassMetadata(new ClassMetadataFactory($loader)),
             );
         });

--- a/tests/Feature/SerializationTest.php
+++ b/tests/Feature/SerializationTest.php
@@ -156,6 +156,19 @@ it('does not include the state ID or last_event_id in its payload', function () 
     expect($result)->toBe('{"__verbs_initialized":false,"name":"Demo"}');
 });
 
+it('allows us to store a serializable class(es) as a property', function () {
+    $original_event = new EventWithPhpDocArray();
+
+    $serialized_data = app(Serializer::class)->serialize($original_event);
+
+    expect($serialized_data)->toBe('{"dto":{"fqcn":"DTO","foo":1},"dtos":[{"fqcn":"DTO","foo":1}]}');
+
+    $deserialized_event = app(Serializer::class)->deserialize(EventWithPhpDocArray::class, $serialized_data);
+
+    expect($deserialized_event->dto)->toBeInstanceOf(DTO::class)
+        ->and($deserialized_event->dtos[0])->toBeInstanceOf(DTO::class);
+});
+
 class EventWithConstructorPromotion extends Event
 {
     public function __construct(
@@ -193,5 +206,15 @@ class EventWithConstructor extends Event
     public function __construct()
     {
         $this->constructed = true;
+    }
+}
+
+class EventWithPhpDocArray extends Event
+{
+    public function __construct(
+        public DTO $dto = new DTO(),
+        /** @var DTO[] $dtos */
+        public array $dtos = [new DTO()]
+    ) {
     }
 }

--- a/tests/Feature/SerializationTest.php
+++ b/tests/Feature/SerializationTest.php
@@ -157,7 +157,7 @@ it('does not include the state ID or last_event_id in its payload', function () 
 });
 
 it('allows us to store a serializable class(es) as a property', function () {
-    $original_event = new EventWithPhpDocArray();
+    $original_event = new EventWithPhpDocArray;
 
     $serialized_data = app(Serializer::class)->serialize($original_event);
 
@@ -212,9 +212,8 @@ class EventWithConstructor extends Event
 class EventWithPhpDocArray extends Event
 {
     public function __construct(
-        public DTO $dto = new DTO(),
+        public DTO $dto = new DTO,
         /** @var DTO[] $dtos */
-        public array $dtos = [new DTO()]
-    ) {
-    }
+        public array $dtos = [new DTO]
+    ) {}
 }


### PR DESCRIPTION
I've added the `PhpDocExtractor` in addition to the `ReflectionExtractor` which allows you to use the phpdoc to decode data properly. That also works in tandem with the array denormalizer (which I've added to the `verbs.php`). Its typically default behaviour to include the `PhpDocExtractor` when the https://symfony.com/doc/current/components/property_info.html#phpdocextractor

I also fixed a bug with the `NormalizeToPropertiesAndClassName`. If the required parameters count is 0 and there's data, the `Arr::has(` will return true causing it to fail for no reason. I found that because the `DTO` class wouldn't serialise for me. I believe the `allows us to store a serializable class as a property` test isn't actually testing anything, otherwise it should've caught it - I wasn't sure so I didn't delete it.

I also believe now the deserialiser is more robust, the BackedEnum code can be removed and I wrote a test to try prove to myself its working fine - but do as you please with that.