### PR TITLE
Fire if valid

### DIFF
--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -6,6 +6,8 @@ use Thunk\Verbs\CommitsImmediately;
 use Thunk\Verbs\Contracts\BrokersEvents;
 use Thunk\Verbs\Contracts\StoresEvents;
 use Thunk\Verbs\Event;
+use Thunk\Verbs\Exceptions\EventNotAuthorized;
+use Thunk\Verbs\Exceptions\EventNotValid;
 use Thunk\Verbs\Lifecycle\Queue as EventQueue;
 
 class Broker implements BrokersEvents
@@ -18,6 +20,15 @@ class Broker implements BrokersEvents
         protected Dispatcher $dispatcher,
         protected MetadataManager $metadata,
     ) {
+    }
+
+    public function fireIfValid(Event $event): ?Event
+    {
+        try {
+            return $this->fire($event);
+        } catch (EventNotValid) {
+            return null;
+        }
     }
 
     public function fire(Event $event): ?Event

--- a/src/Support/PendingEvent.php
+++ b/src/Support/PendingEvent.php
@@ -3,18 +3,19 @@
 namespace Thunk\Verbs\Support;
 
 use Closure;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Traits\Conditionable;
-use Illuminate\Support\Traits\Macroable;
-use Illuminate\Validation\ValidationException;
-use InvalidArgumentException;
-use ReflectionMethod;
-use ReflectionParameter;
-use RuntimeException;
 use Throwable;
-use Thunk\Verbs\Contracts\BrokersEvents;
+use ReflectionMethod;
+use RuntimeException;
 use Thunk\Verbs\Event;
+use ReflectionParameter;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+use Illuminate\Support\Traits\Macroable;
+use Thunk\Verbs\Contracts\BrokersEvents;
+use Thunk\Verbs\Exceptions\EventNotValid;
 use Thunk\Verbs\Lifecycle\MetadataManager;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Validation\ValidationException;
 
 /**
  * @template TEventType of Event
@@ -111,6 +112,16 @@ class PendingEvent
             return app(BrokersEvents::class)->fire($this->event);
         } catch (Throwable $e) {
             throw $this->prepareException($e);
+        }
+    }
+
+    /** @return null|TEventType */
+    public function fireIfValid(...$args): ?Event
+    {
+        try {
+            return $this->fire(...$args);
+        } catch (EventNotValid) {
+            return null;
         }
     }
 

--- a/src/Support/PendingEvent.php
+++ b/src/Support/PendingEvent.php
@@ -3,19 +3,19 @@
 namespace Thunk\Verbs\Support;
 
 use Closure;
-use Throwable;
-use ReflectionMethod;
-use RuntimeException;
-use Thunk\Verbs\Event;
-use ReflectionParameter;
 use Illuminate\Support\Arr;
-use InvalidArgumentException;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\ValidationException;
+use InvalidArgumentException;
+use ReflectionMethod;
+use ReflectionParameter;
+use RuntimeException;
+use Throwable;
 use Thunk\Verbs\Contracts\BrokersEvents;
+use Thunk\Verbs\Event;
 use Thunk\Verbs\Exceptions\EventNotValid;
 use Thunk\Verbs\Lifecycle\MetadataManager;
-use Illuminate\Support\Traits\Conditionable;
-use Illuminate\Validation\ValidationException;
 
 /**
  * @template TEventType of Event

--- a/tests/Feature/PendingEventChecksTest.php
+++ b/tests/Feature/PendingEventChecksTest.php
@@ -2,6 +2,7 @@
 
 use Thunk\Verbs\Attributes\Autodiscovery\StateId;
 use Thunk\Verbs\Event;
+use Thunk\Verbs\Exceptions\EventNotValid;
 use Thunk\Verbs\State;
 
 it('can test authorization on a pending event', function () {
@@ -72,6 +73,33 @@ it('can test validation on a pending event', function () {
     ]);
 
     $this->assertFalse($event->isValid());
+});
+
+it('can not throw an exception if the event is fired using fireIfValid', function () {
+    SpecialState::factory()->id(1)->create([
+        'name' => 'daniel',
+    ]);
+
+    // this is invalid and will cause validation to fail
+    OtherState::factory()->id(3)->create([
+        'name' => 'john',
+    ]);
+
+    expect(
+        fn() => EventWithMultipleStates::fireIfValid([
+            'special_id' => 1,
+            'other_id' => 3,
+            'allowed' => true,
+        ])
+    )->not->toThrow(EventNotValid::class);
+
+    expect(
+        fn() => EventWithMultipleStates::fire([
+            'special_id' => 1,
+            'other_id' => 3,
+            'allowed' => true,
+        ])
+    )->toThrow(EventNotValid::class);
 });
 
 class EventWithBooleanAuth extends Event

--- a/tests/Feature/PendingEventChecksTest.php
+++ b/tests/Feature/PendingEventChecksTest.php
@@ -86,7 +86,7 @@ it('can not throw an exception if the event is fired using fireIfValid', functio
     ]);
 
     expect(
-        fn() => EventWithMultipleStates::fireIfValid([
+        fn () => EventWithMultipleStates::fireIfValid([
             'special_id' => 1,
             'other_id' => 3,
             'allowed' => true,
@@ -94,7 +94,7 @@ it('can not throw an exception if the event is fired using fireIfValid', functio
     )->not->toThrow(EventNotValid::class);
 
     expect(
-        fn() => EventWithMultipleStates::fire([
+        fn () => EventWithMultipleStates::fire([
             'special_id' => 1,
             'other_id' => 3,
             'allowed' => true,


### PR DESCRIPTION
This allows us to fire an event in a way that will not throw an exception if it fails validation. 

This is useful in cases where we want to use validation logic to determine if an event should fire or not, but either outcome is acceptable.

For Example:

This event might fire with a side effect event that sends a notification
```php
class UserLikedPost
{
    #[StateId(UserState::class)]
    public int $user_id;

    #[StateId(PostState::class)]
    public int $post_state;

    function fired(PostState $post)
    {
        UserNotifiedAboutPostLike::fireIfValid(post_id: $post->id);
    }
}
```

The validation on the side effect event can fail without interrupting the primary logic
```php
class UserNotifiedAboutPostLike
{
    #[StateId(UserState::class)]
    public int $user_id;

    #[StateId(PostState::class)]
    public int $post_state;

    function validate(UserState $user)
    {
        $this->assert(
            $user->notifications_enabled,
            'This user hates emails'
        );
    }
}
```