### PR TITLE
Skip phases

### DIFF
--- a/src/Facades/Verbs.php
+++ b/src/Facades/Verbs.php
@@ -2,14 +2,14 @@
 
 namespace Thunk\Verbs\Facades;
 
-use Closure;
-use Thunk\Verbs\Event;
 use Carbon\CarbonInterface;
+use Closure;
+use Illuminate\Support\Facades\Facade;
+use Thunk\Verbs\Contracts\BrokersEvents;
+use Thunk\Verbs\Event;
 use Thunk\Verbs\Lifecycle\Phase;
 use Thunk\Verbs\Testing\BrokerFake;
-use Illuminate\Support\Facades\Facade;
 use Thunk\Verbs\Testing\EventStoreFake;
-use Thunk\Verbs\Contracts\BrokersEvents;
 
 /**
  * @method static bool commit()

--- a/src/Facades/Verbs.php
+++ b/src/Facades/Verbs.php
@@ -2,13 +2,14 @@
 
 namespace Thunk\Verbs\Facades;
 
-use Carbon\CarbonInterface;
 use Closure;
-use Illuminate\Support\Facades\Facade;
-use Thunk\Verbs\Contracts\BrokersEvents;
 use Thunk\Verbs\Event;
+use Carbon\CarbonInterface;
+use Thunk\Verbs\Lifecycle\Phase;
 use Thunk\Verbs\Testing\BrokerFake;
+use Illuminate\Support\Facades\Facade;
 use Thunk\Verbs\Testing\EventStoreFake;
+use Thunk\Verbs\Contracts\BrokersEvents;
 
 /**
  * @method static bool commit()
@@ -21,6 +22,7 @@ use Thunk\Verbs\Testing\EventStoreFake;
  * @method static EventStoreFake assertNotCommitted(string|Closure $event, ?Closure $callback = null)
  * @method static EventStoreFake assertNothingCommitted()
  * @method static CarbonInterface realNow()
+ * @method static void skipPhases(Phase ...$phases)
  */
 class Verbs extends Facade
 {

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -111,4 +111,9 @@ class Broker implements BrokersEvents
     {
         $this->commit_immediately = $commit_immediately;
     }
+
+    public function skipPhases(Phase ...$phases): void
+    {
+        $this->dispatcher->skipPhases(...$phases);
+    }
 }

--- a/tests/Feature/SkipPhasesTest.php
+++ b/tests/Feature/SkipPhasesTest.php
@@ -101,7 +101,6 @@ it('can reset skipped phases', function () use ($snowflake) {
 
     $state = HooksState::load($snowflake);
 
-
     Verbs::skipPhases();
 
     EventHitHooks::fire(state_id: $snowflake);

--- a/tests/Feature/SkipPhasesTest.php
+++ b/tests/Feature/SkipPhasesTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use Thunk\Verbs\Event;
+use Thunk\Verbs\State;
+use Thunk\Verbs\Facades\Verbs;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Lifecycle\Phase;
+
+$snowflake = 170622032481976320;
+
+it('hits all hooks by default', function () use ($snowflake) {
+    $state = HooksState::load($snowflake);
+
+    EventHitHooks::fire(state_id: $snowflake);
+
+    Verbs::commit();
+
+    expect($state->validate)->toBeTrue();
+    expect($state->fired)->toBeTrue();
+    expect($state->apply)->toBeTrue();
+    expect($state->handle)->toBeTrue();
+});
+
+it('skips validation when set to', function () use ($snowflake) {
+    Verbs::skipPhases(Phase::Validate);
+
+    $state = HooksState::load($snowflake);
+
+    EventHitHooks::fire(state_id: $snowflake);
+
+    Verbs::commit();
+
+    expect($state->validate)->toBeFalse();
+    expect($state->fired)->toBeTrue();
+    expect($state->apply)->toBeTrue();
+    expect($state->handle)->toBeTrue();
+});
+
+it('skips apply when set to', function () use ($snowflake) {
+    Verbs::skipPhases(Phase::Apply);
+
+    $state = HooksState::load($snowflake);
+
+    EventHitHooks::fire(state_id: $snowflake);
+
+    Verbs::commit();
+
+    expect($state->validate)->toBeTrue();
+    expect($state->fired)->toBeTrue();
+    expect($state->apply)->toBeFalse();
+    expect($state->handle)->toBeTrue();
+});
+
+it('skips handle when set to', function () use ($snowflake) {
+    Verbs::skipPhases(Phase::Handle);
+
+    $state = HooksState::load($snowflake);
+
+    EventHitHooks::fire(state_id: $snowflake);
+
+    Verbs::commit();
+
+    expect($state->validate)->toBeTrue();
+    expect($state->fired)->toBeTrue();
+    expect($state->apply)->toBeTrue();
+    expect($state->handle)->toBeFalse();
+});
+
+it('skips fired when set to', function () use ($snowflake) {
+    Verbs::skipPhases(Phase::Fired);
+
+    $state = HooksState::load($snowflake);
+
+    EventHitHooks::fire(state_id: $snowflake);
+
+    Verbs::commit();
+
+    expect($state->validate)->toBeTrue();
+    expect($state->fired)->toBeFalse();
+    expect($state->apply)->toBeTrue();
+    expect($state->handle)->toBeTrue();
+});
+
+it('skips all hooks when set to', function () use ($snowflake) {
+    Verbs::skipPhases(Phase::Validate, Phase::Apply, Phase::Handle, Phase::Fired);
+
+    $state = HooksState::load($snowflake);
+
+    EventHitHooks::fire(state_id: $snowflake);
+
+    Verbs::commit();
+
+    expect($state->validate)->toBeFalse();
+    expect($state->fired)->toBeFalse();
+    expect($state->apply)->toBeFalse();
+    expect($state->handle)->toBeFalse();
+});
+
+class HooksState extends State
+{
+    public $validate = false;
+    public $fired = false;
+    public $apply = false;
+    public $handle = false;
+}
+
+class EventHitHooks extends Event
+{
+    #[StateId(HooksState::class)]
+    public int $state_id;
+
+    public function validate(HooksState $state): void
+    {
+        $state->validate = true;
+    }
+
+    public function fired(HooksState $state): void
+    {
+        $state->fired = true;
+    }
+
+    public function apply(HooksState $state): void
+    {
+        $state->apply = true;
+    }
+
+    public function handle(HooksState $state): void
+    {
+        $state->handle = true;
+    }
+}

--- a/tests/Feature/SkipPhasesTest.php
+++ b/tests/Feature/SkipPhasesTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use Thunk\Verbs\Event;
-use Thunk\Verbs\State;
-use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\Lifecycle\Phase;
+use Thunk\Verbs\State;
 
 $snowflake = 170622032481976320;
 
@@ -99,8 +99,11 @@ it('skips all hooks when set to', function () use ($snowflake) {
 class HooksState extends State
 {
     public $validate = false;
+
     public $fired = false;
+
     public $apply = false;
+
     public $handle = false;
 }
 

--- a/tests/Feature/SkipPhasesTest.php
+++ b/tests/Feature/SkipPhasesTest.php
@@ -96,6 +96,24 @@ it('skips all hooks when set to', function () use ($snowflake) {
     expect($state->handle)->toBeFalse();
 });
 
+it('can reset skipped phases', function () use ($snowflake) {
+    Verbs::skipPhases(Phase::Validate, Phase::Apply, Phase::Handle, Phase::Fired);
+
+    $state = HooksState::load($snowflake);
+
+
+    Verbs::skipPhases();
+
+    EventHitHooks::fire(state_id: $snowflake);
+
+    Verbs::commit();
+
+    expect($state->validate)->toBeTrue();
+    expect($state->fired)->toBeTrue();
+    expect($state->apply)->toBeTrue();
+    expect($state->handle)->toBeTrue();
+});
+
 class HooksState extends State
 {
     public $validate = false;


### PR DESCRIPTION
This PR adds a `Verbs::skipPhases()` method that causes Verbs not to execute any hooks for one or more phases.

Useful when testing or for certain weird business logic (in our case, ephemeral event queues)

## Usage

```php
Verbs::skipPhases(Phase::Apply, Phase::Handle);
```

This will cause all hooks for the Apply and Handle phases (like the `apply()` and `handle()` methods of many events) not to fire.

To reset skipped phases just call the method with no arguments.

```php
Verbs::skipPhases();
```
