### PR TITLE
Set `last_event_id` in Dispatcher

### DIFF
--- a/src/Lifecycle/Hook.php
+++ b/src/Lifecycle/Hook.php
@@ -89,7 +89,6 @@ class Hook
     {
         if ($this->runsInPhase(Phase::Apply)) {
             $container->call($this->callback, $this->guessParameters($event, $state));
-            $state->last_event_id = $event->id;
         }
     }
 


### PR DESCRIPTION
Right now we only set `State::$last_event_id` if an `apply` hook is triggered. This means that events that don't have an apply method can trigger concurrency exceptions, even thought it's not a concurrency issue. This change should resolve that byt setting `last_event_id` when the event is dispatched regardless of whether there are any hooks registered for that phase.