### PR TITLE
Use existing event object in `verb()` helper

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -13,7 +13,7 @@ if (! function_exists('verb')) {
      */
     function verb(Event $event, bool $commit = false): Event
     {
-        $event = (new PendingEvent($event))->fire();
+        (new PendingEvent($event))->fire();
 
         if ($commit) {
             app(BrokersEvents::class)->commit();


### PR DESCRIPTION
It's possible for `PendingEvent::fire()` to return null if you're firing an event from a `handle` method during replay. This is the correct behavior, but breaks the type expectations of `verb()`. The fix is to just return the original event, rather than rewriting the variable.