### PR TITLE
Add LRU cache for state manager

### DIFF
--- a/config/verbs.php
+++ b/config/verbs.php
@@ -108,4 +108,20 @@ return [
     | If you want to always manually commit, you can disable auto-commit.
     */
     'autocommit' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | State Cache Size
+    |--------------------------------------------------------------------------
+    |
+    | By default, Verbs will keep up to 100 State objects in memory at one time.
+    | Most applications will never need more than a handful of States for any
+    | given request, so this limit will only make any difference when you're
+    | replaying events.
+    |
+    | If your application needs to operate on more than 100 States at any given
+    | time, you should increase this setting to some value higher than the
+    | maximum number of States you will ever need.
+    */
+    'state_cache_size' => 100,
 ];

--- a/docs/states.md
+++ b/docs/states.md
@@ -247,3 +247,9 @@ class FooCreated class
 That said: if you ever find yourself storing complex, nested, multi-faceted data in arrays, collections, or objects on your state, you __probably__ need another state. Particularly if the data in those collections, arrays, or objects is ever going to change.
 
 Read more about the role states play in [State-first development](/docs/techniques/state-first-development).
+
+## State Cache
+
+By default, Verbs keeps up to 100 State objects in memory at one time. Most applications will never need more than a 
+handful of States for any given request, but if your application needs to operate on hundreds of States during a single
+request/command/job, you’ll need to increase the `state_cache_size` configuration value.

--- a/src/Exceptions/StateCacheSizeTooLow.php
+++ b/src/Exceptions/StateCacheSizeTooLow.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Thunk\Verbs\Exceptions;
+
+use RuntimeException;
+
+class StateCacheSizeTooLow extends RuntimeException
+{
+    public function __construct()
+    {
+        $url = 'https://verbs.thunk.dev/docs/reference/states#content-state-cache';
+        $size = config('verbs.state_cache_size', 100);
+
+        parent::__construct("Your 'state_cache_size' config value of '{$size}' is too low. See <{$url}>.");
+    }
+}

--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -8,6 +8,7 @@ use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Contracts\StoresEvents;
 use Thunk\Verbs\Contracts\StoresSnapshots;
 use Thunk\Verbs\Event;
+use Thunk\Verbs\Exceptions\StateCacheSizeTooLow;
 use Thunk\Verbs\Facades\Id;
 use Thunk\Verbs\State;
 use Thunk\Verbs\Support\LeastRecentlyUsedCache;
@@ -23,8 +24,7 @@ class StateManager
         protected StoresEvents $events,
         protected LeastRecentlyUsedCache $states,
     ) {
-        // If a state gets ejected from the cache, we need to write the snapshot first
-        $this->states->onDiscard(fn (State $discarded) => $this->snapshots->write([$discarded]));
+        $this->states->onDiscard(fn () => throw_unless($this->is_replaying, StateCacheSizeTooLow::class));
     }
 
     public function register(State $state): State

--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -3,7 +3,6 @@
 namespace Thunk\Verbs\Lifecycle;
 
 use Glhd\Bits\Bits;
-use Illuminate\Database\Eloquent\Collection;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Contracts\StoresEvents;

--- a/src/Support/LeastRecentlyUsedCache.php
+++ b/src/Support/LeastRecentlyUsedCache.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Thunk\Verbs\Support;
+
+use Closure;
+
+class LeastRecentlyUsedCache
+{
+    public function __construct(
+        protected int $capacity = 100,
+        protected array $cache = [],
+        protected ?Closure $discard_callback = null,
+    ) {
+    }
+
+    public function remember(string|int $key, Closure $callback): mixed
+    {
+        if ($this->has($key)) {
+            return $this->get($key);
+        }
+
+        $this->put($key, $value = $callback());
+
+        return $value;
+    }
+
+    public function get(string|int $key, mixed $default = null): mixed
+    {
+        if ($this->has($key)) {
+            $this->touch($key);
+
+            return $this->cache[$key];
+        }
+
+        return value($default);
+    }
+
+    public function put(string|int $key, mixed $value): static
+    {
+        if (isset($this->cache[$key])) {
+            unset($this->cache[$key]);
+        }
+
+        $this->cache[$key] = $value;
+
+        if (count($this->cache) > $this->capacity) {
+            reset($this->cache);
+            $this->forget(key($this->cache));
+        }
+
+        return $this;
+    }
+
+    public function has(string|int $key): bool
+    {
+        return isset($this->cache[$key]);
+    }
+
+    public function forget(string|int $key): static
+    {
+        if ($this->discard_callback) {
+            call_user_func($this->discard_callback, $this->cache[$key]);
+        }
+
+        unset($this->cache[$key]);
+
+        return $this;
+    }
+
+    public function values(): array
+    {
+        return $this->cache;
+    }
+
+    public function reset(): static
+    {
+        $this->cache = [];
+
+        return $this;
+    }
+
+    public function onDiscard(Closure $callback): static
+    {
+        $this->discard_callback = $callback;
+
+        return $this;
+    }
+
+    protected function touch($key): void
+    {
+        $value = $this->cache[$key];
+
+        unset($this->cache[$key]);
+
+        $this->cache[$key] = $value;
+    }
+}

--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -156,6 +156,7 @@ class VerbsServiceProvider extends PackageServiceProvider
 
         $this->app->terminating(function () {
             app(AutoCommitManager::class)->commitIfAutoCommitting();
+            app(StateManager::class)->reset(include_storage: false);
         });
 
         // Hook into Laravel event dispatcher
@@ -174,6 +175,7 @@ class VerbsServiceProvider extends PackageServiceProvider
         // Auto-commit after each job on the queue is processed
         if ($event instanceof JobProcessed) {
             app(AutoCommitManager::class)->commitIfAutoCommitting();
+            app(StateManager::class)->reset(include_storage: false);
         }
     }
 }

--- a/tests/Unit/LruCacheTest.php
+++ b/tests/Unit/LruCacheTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Thunk\Verbs\Support\LeastRecentlyUsedCache;
+
+it('implements a least-recently-used strategy', function () {
+    $lru = new LeastRecentlyUsedCache(capacity: 5);
+
+    $lru->put('a', 1)->put('b', 2)->put('c', 3)->put('d', 4)->put('e', 5);
+
+    expect($lru->values())->toBe(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5]);
+
+    $lru->put('f', 6);
+
+    expect($lru->has('a'))->toBeFalse()
+        ->and($lru->has('f'))->toBeTrue()
+        ->and($lru->values())->toBe(['b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6]);
+
+    $lru->get('b');
+
+    expect($lru->values())->toBe(['c' => 3, 'd' => 4, 'e' => 5, 'f' => 6, 'b' => 2]);
+
+    $lru->put('a', 1);
+
+    expect($lru->has('c'))->toBeFalse()
+        ->and($lru->values())->toBe(['d' => 4, 'e' => 5, 'f' => 6, 'b' => 2, 'a' => 1]);
+
+    $lru->forget('e');
+
+    expect($lru->has('e'))->toBeFalse()
+        ->and($lru->values())->toBe(['d' => 4, 'f' => 6, 'b' => 2, 'a' => 1]);
+});

--- a/tests/Unit/StateManagerTest.php
+++ b/tests/Unit/StateManagerTest.php
@@ -12,8 +12,7 @@ use Thunk\Verbs\Testing\SnapshotStoreFake;
 beforeEach(function () {
     app()->instance(StoresSnapshots::class, new SnapshotStoreFake());
     app()->instance(StoresEvents::class, new EventStoreFake(app(MetadataManager::class)));
-}
-);
+});
 
 test('loadOrFail triggers an exception if state does not exist', function () {
     StateManagerTestState::loadOrFail(1);


### PR DESCRIPTION
When replaying events, it's possible to load 100,000's of State objects into memory. This implements a least-recently-used ("LRU") cache for the state manager, that will automatically purge the oldest states from memory. This should help with replays.