### PR TITLE
[BUG] Use wormhole during the apply phase

### DIFF
--- a/src/Lifecycle/Hook.php
+++ b/src/Lifecycle/Hook.php
@@ -88,7 +88,7 @@ class Hook
     public function apply(Container $container, Event $event, State $state): void
     {
         if ($this->runsInPhase(Phase::Apply)) {
-            $container->call($this->callback, $this->guessParameters($event, $state));
+            app(Wormhole::class)->process($event, fn () => $container->call($this->callback, $this->guessParameters($event, $state)));
         }
     }
 

--- a/src/Lifecycle/Hook.php
+++ b/src/Lifecycle/Hook.php
@@ -111,7 +111,7 @@ class Hook
     public function replay(Container $container, Event $event, StateCollection $states): void
     {
         if ($this->runsInPhase(Phase::Replay)) {
-            app(Wormhole::class)->replay($event, fn () => $container->call($this->callback, $this->guessParameters($event, states: $states)));
+            app(Wormhole::class)->process($event, fn () => $container->call($this->callback, $this->guessParameters($event, states: $states)));
         }
     }
 

--- a/src/Lifecycle/Hook.php
+++ b/src/Lifecycle/Hook.php
@@ -88,7 +88,7 @@ class Hook
     public function apply(Container $container, Event $event, State $state): void
     {
         if ($this->runsInPhase(Phase::Apply)) {
-            app(Wormhole::class)->process($event, fn () => $container->call($this->callback, $this->guessParameters($event, $state)));
+            app(Wormhole::class)->warp($event, fn () => $container->call($this->callback, $this->guessParameters($event, $state)));
         }
     }
 
@@ -111,7 +111,7 @@ class Hook
     public function replay(Container $container, Event $event, StateCollection $states): void
     {
         if ($this->runsInPhase(Phase::Replay)) {
-            app(Wormhole::class)->process($event, fn () => $container->call($this->callback, $this->guessParameters($event, states: $states)));
+            app(Wormhole::class)->warp($event, fn () => $container->call($this->callback, $this->guessParameters($event, states: $states)));
         }
     }
 

--- a/src/Support/Wormhole.php
+++ b/src/Support/Wormhole.php
@@ -42,7 +42,7 @@ class Wormhole
         return $this->immutable_now ?? CarbonImmutable::instance(new DateTime());
     }
 
-    public function replay(Event $event, Closure $callback)
+    public function process(Event $event, Closure $callback)
     {
         if ($this->wormholeIsDisabled($event)) {
             return $callback();

--- a/src/Support/Wormhole.php
+++ b/src/Support/Wormhole.php
@@ -42,7 +42,7 @@ class Wormhole
         return $this->immutable_now ?? CarbonImmutable::instance(new DateTime());
     }
 
-    public function process(Event $event, Closure $callback)
+    public function warp(Event $event, Closure $callback)
     {
         if ($this->wormholeIsDisabled($event)) {
             return $callback();

--- a/tests/Feature/ReplayCommandTest.php
+++ b/tests/Feature/ReplayCommandTest.php
@@ -121,7 +121,8 @@ class ReplayCommandTestWormholeEvent extends Event
 {
     public function __construct(
         #[StateId(ReplayCommandTestWormholeState::class)] public ?int $state_id = null
-    ){}
+    ) {
+    }
 
     public function apply(ReplayCommandTestWormholeState $state): void
     {

--- a/tests/Feature/ReplayCommandTest.php
+++ b/tests/Feature/ReplayCommandTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\CarbonImmutable;
 use Thunk\Verbs\Attributes\Autodiscovery\StateId;
 use Thunk\Verbs\Commands\ReplayCommand;
 use Thunk\Verbs\Event;
@@ -11,6 +12,7 @@ use Thunk\Verbs\State;
 beforeEach(function () {
     $GLOBALS['replay_test_counts'] = [];
     $GLOBALS['handle_count'] = 0;
+    $GLOBALS['times'] = [];
 });
 
 it('can replay events', function () {
@@ -61,6 +63,30 @@ it('can replay events', function () {
         ->and($GLOBALS['handle_count'])->toBe(1337);
 });
 
+it('uses the original event times when replaying', function () {
+    \Illuminate\Support\Facades\Date::setTestNow('2024-04-01 12:00:00');
+    $state_id = Id::make();
+    ReplayCommandTestWormholeEvent::fire(state_id: $state_id);
+
+    Verbs::commit();
+
+    expect(app(StateManager::class)->load($state_id, ReplayCommandTestWormholeState::class)->time->unix())
+        ->toBe(CarbonImmutable::parse('2024-04-01 12:00:00')->unix())
+        ->and($GLOBALS['time'][$state_id]->unix())
+        ->toBe(CarbonImmutable::parse('2024-04-01 12:00:00')->unix());
+
+    $GLOBALS['time'] = [];
+    \Illuminate\Support\Facades\Date::setTestNow('2024-05-15 18:00:00');
+
+    config(['app.env' => 'testing']);
+    $this->artisan(ReplayCommand::class);
+
+    expect(app(StateManager::class)->load($state_id, ReplayCommandTestWormholeState::class)->time->unix())
+        ->toBe(CarbonImmutable::parse('2024-04-01 12:00:00')->unix())
+        ->and($GLOBALS['time'][$state_id]->unix())
+        ->toBe(CarbonImmutable::parse('2024-04-01 12:00:00')->unix());
+});
+
 class ReplayCommandTestEvent extends Event
 {
     public function __construct(
@@ -89,4 +115,26 @@ class ReplayCommandTestEvent extends Event
 class ReplayCommandTestState extends State
 {
     public int $count = 0;
+}
+
+class ReplayCommandTestWormholeEvent extends Event
+{
+    public function __construct(
+        #[StateId(ReplayCommandTestWormholeState::class)] public ?int $state_id = null
+    ){}
+
+    public function apply(ReplayCommandTestWormholeState $state): void
+    {
+        $state->time = CarbonImmutable::now();
+    }
+
+    public function handle(): void
+    {
+        $GLOBALS['time'][$this->state_id] = $this->state(ReplayCommandTestWormholeState::class)->time;
+    }
+}
+
+class ReplayCommandTestWormholeState extends State
+{
+    public CarbonImmutable $time;
 }

--- a/tests/Unit/WormholeTest.php
+++ b/tests/Unit/WormholeTest.php
@@ -14,7 +14,7 @@ test('a callback can be run for a past timestamp', function () {
     {
     };
     app(MetadataManager::class)->setEphemeral($event, 'created_at', Date::parse('2023-01-02 00:00:00'));
-    app(Wormhole::class)->replay($event, function () use ($now) {
+    app(Wormhole::class)->process($event, function () use ($now) {
         expect(Carbon::now()->format('Y-m-d'))->toBe('2023-01-02')
             ->and(CarbonImmutable::now()->format('Y-m-d'))->toBe('2023-01-02')
             ->and(now()->format('Y-m-d'))->toBe('2023-01-02')
@@ -29,7 +29,7 @@ test('a callback can be run for a past timestamp with "test now" set', function 
     {
     };
     app(MetadataManager::class)->setEphemeral($event, 'created_at', Date::parse('2023-01-02 00:00:00'));
-    app(Wormhole::class)->replay($event, function () {
+    app(Wormhole::class)->process($event, function () {
         expect(Carbon::now()->format('Y-m-d'))->toBe('2023-01-02')
             ->and(CarbonImmutable::now()->format('Y-m-d'))->toBe('2023-01-02')
             ->and(now()->format('Y-m-d'))->toBe('2023-01-02')

--- a/tests/Unit/WormholeTest.php
+++ b/tests/Unit/WormholeTest.php
@@ -14,7 +14,7 @@ test('a callback can be run for a past timestamp', function () {
     {
     };
     app(MetadataManager::class)->setEphemeral($event, 'created_at', Date::parse('2023-01-02 00:00:00'));
-    app(Wormhole::class)->process($event, function () use ($now) {
+    app(Wormhole::class)->warp($event, function () use ($now) {
         expect(Carbon::now()->format('Y-m-d'))->toBe('2023-01-02')
             ->and(CarbonImmutable::now()->format('Y-m-d'))->toBe('2023-01-02')
             ->and(now()->format('Y-m-d'))->toBe('2023-01-02')
@@ -29,7 +29,7 @@ test('a callback can be run for a past timestamp with "test now" set', function 
     {
     };
     app(MetadataManager::class)->setEphemeral($event, 'created_at', Date::parse('2023-01-02 00:00:00'));
-    app(Wormhole::class)->process($event, function () {
+    app(Wormhole::class)->warp($event, function () {
         expect(Carbon::now()->format('Y-m-d'))->toBe('2023-01-02')
             ->and(CarbonImmutable::now()->format('Y-m-d'))->toBe('2023-01-02')
             ->and(now()->format('Y-m-d'))->toBe('2023-01-02')


### PR DESCRIPTION
When replaying events we were not using the `Wormhole` and as a result any uses of `Carbon::now()` were not being honored, causing weird side effects.

I renamed `Wormhole::replay()` to `Wormhole::process()` because I wanted to use it in both `replay` and `apply`