### PR TITLE
Don't hydrate unset properties

### DIFF
--- a/src/Support/Normalization/NormalizeToPropertiesAndClassName.php
+++ b/src/Support/Normalization/NormalizeToPropertiesAndClassName.php
@@ -72,6 +72,7 @@ trait NormalizeToPropertiesAndClassName
     {
         $properties = Collection::make((new ReflectionClass($this))->getProperties())
             ->reject(fn (ReflectionProperty $property) => $property->isStatic())
+            ->filter(fn (ReflectionProperty $property) => $property->isInitialized($this))
             ->mapWithKeys(fn (ReflectionProperty $property) => [$property->getName() => $property->getValue($this)]);
 
         if ($properties->has('fqcn')) {


### PR DESCRIPTION
Imagine the following object:

```php
class Foo 
{
    string $bar;
    int $baz;
}
```

serializing an object where $baz had not been set yet (even though it's not nullable, i know, I'm bad) would result in rehydrating it with a value of null, which would blow up because it isn't typehinted to null

This fixes that, so we only rehydrate values that are instantiated.