### PR TITLE
State instance cache

### DIFF
--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -11,7 +11,7 @@ use Thunk\Verbs\Event;
 use Thunk\Verbs\Exceptions\StateCacheSizeTooLow;
 use Thunk\Verbs\Facades\Id;
 use Thunk\Verbs\State;
-use Thunk\Verbs\Support\LeastRecentlyUsedCache;
+use Thunk\Verbs\Support\StateInstanceCache;
 use UnexpectedValueException;
 
 class StateManager
@@ -22,7 +22,7 @@ class StateManager
         protected Dispatcher $dispatcher,
         protected StoresSnapshots $snapshots,
         protected StoresEvents $events,
-        protected LeastRecentlyUsedCache $states,
+        protected StateInstanceCache $states,
     ) {
         $this->states->onDiscard(fn () => throw_unless($this->is_replaying, StateCacheSizeTooLow::class));
     }
@@ -98,6 +98,13 @@ class StateManager
         if ($include_storage) {
             $this->snapshots->reset();
         }
+
+        return $this;
+    }
+
+    public function prune(): static
+    {
+        $this->states->prune();
 
         return $this;
     }

--- a/src/Support/StateInstanceCache.php
+++ b/src/Support/StateInstanceCache.php
@@ -4,7 +4,7 @@ namespace Thunk\Verbs\Support;
 
 use Closure;
 
-class LeastRecentlyUsedCache
+class StateInstanceCache
 {
     public function __construct(
         protected int $capacity = 100,
@@ -43,11 +43,6 @@ class LeastRecentlyUsedCache
 
         $this->cache[$key] = $value;
 
-        if (count($this->cache) > $this->capacity) {
-            reset($this->cache);
-            $this->forget(key($this->cache));
-        }
-
         return $this;
     }
 
@@ -63,6 +58,13 @@ class LeastRecentlyUsedCache
         }
 
         unset($this->cache[$key]);
+
+        return $this;
+    }
+
+    public function prune(): static
+    {
+        $this->cache = array_slice($this->cache, -1 * $this->capacity, null, true);
 
         return $this;
     }

--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -34,7 +34,7 @@ use Thunk\Verbs\Lifecycle\StateManager;
 use Thunk\Verbs\Livewire\SupportVerbs;
 use Thunk\Verbs\Support\EventStateRegistry;
 use Thunk\Verbs\Support\IdManager;
-use Thunk\Verbs\Support\LeastRecentlyUsedCache;
+use Thunk\Verbs\Support\StateInstanceCache;
 use Thunk\Verbs\Support\Serializer;
 use Thunk\Verbs\Support\Wormhole;
 
@@ -77,7 +77,7 @@ class VerbsServiceProvider extends PackageServiceProvider
                 dispatcher: $app->make(Dispatcher::class),
                 snapshots: $app->make(StoresSnapshots::class),
                 events: $app->make(StoresEvents::class),
-                states: new LeastRecentlyUsedCache(
+                states: new StateInstanceCache(
                     capacity: $app->make(Repository::class)->get('verbs.state_cache_size', 100)
                 ),
             );
@@ -156,7 +156,6 @@ class VerbsServiceProvider extends PackageServiceProvider
 
         $this->app->terminating(function () {
             app(AutoCommitManager::class)->commitIfAutoCommitting();
-            app(StateManager::class)->reset(include_storage: false);
         });
 
         // Hook into Laravel event dispatcher
@@ -175,7 +174,6 @@ class VerbsServiceProvider extends PackageServiceProvider
         // Auto-commit after each job on the queue is processed
         if ($event instanceof JobProcessed) {
             app(AutoCommitManager::class)->commitIfAutoCommitting();
-            app(StateManager::class)->reset(include_storage: false);
         }
     }
 }

--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -34,8 +34,8 @@ use Thunk\Verbs\Lifecycle\StateManager;
 use Thunk\Verbs\Livewire\SupportVerbs;
 use Thunk\Verbs\Support\EventStateRegistry;
 use Thunk\Verbs\Support\IdManager;
-use Thunk\Verbs\Support\StateInstanceCache;
 use Thunk\Verbs\Support\Serializer;
+use Thunk\Verbs\Support\StateInstanceCache;
 use Thunk\Verbs\Support\Wormhole;
 
 class VerbsServiceProvider extends PackageServiceProvider

--- a/tests/Unit/LruCacheTest.php
+++ b/tests/Unit/LruCacheTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Thunk\Verbs\Support\LeastRecentlyUsedCache;
+use Thunk\Verbs\Support\StateInstanceCache;
 
-it('implements a least-recently-used strategy', function () {
-    $lru = new LeastRecentlyUsedCache(capacity: 5);
+it('can be pruned', function () {
+    $lru = new StateInstanceCache(capacity: 5);
 
     $lru->put('a', 1)->put('b', 2)->put('c', 3)->put('d', 4)->put('e', 5);
 
@@ -11,21 +11,13 @@ it('implements a least-recently-used strategy', function () {
 
     $lru->put('f', 6);
 
-    expect($lru->has('a'))->toBeFalse()
-        ->and($lru->has('f'))->toBeTrue()
-        ->and($lru->values())->toBe(['b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6]);
+    expect($lru->values())->toBe(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6]);
 
     $lru->get('b');
 
+    expect($lru->values())->toBe(['a' => 1, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6, 'b' => 2]);
+
+    $lru->prune();
+
     expect($lru->values())->toBe(['c' => 3, 'd' => 4, 'e' => 5, 'f' => 6, 'b' => 2]);
-
-    $lru->put('a', 1);
-
-    expect($lru->has('c'))->toBeFalse()
-        ->and($lru->values())->toBe(['d' => 4, 'e' => 5, 'f' => 6, 'b' => 2, 'a' => 1]);
-
-    $lru->forget('e');
-
-    expect($lru->has('e'))->toBeFalse()
-        ->and($lru->values())->toBe(['d' => 4, 'f' => 6, 'b' => 2, 'a' => 1]);
 });


### PR DESCRIPTION
The LRU cache implementation can cause issues when interacting with the queue in tests. This changes the implementation to prune the state cache between replay cycles, rather than using a traditional LRU strategy.