### PR TITLE
Add migration helpers note to IDs docs page

### DIFF
--- a/docs/ids.md
+++ b/docs/ids.md
@@ -23,6 +23,25 @@ class JobApplication extends Model
 }
 ```
 
+Bits also provides helpers for your migrations:
+
+```php
+/**
+ * Run the migrations.
+ */
+public function up(): void
+{
+    Schema::create('job_applications', function (Blueprint $table) {
+        $table->snowflakeId();
+        $table->snowflake('user_id')->index();
+        $table->foreign('user_id')->references('id')->on('users');
+        // ...
+    });
+}
+```
+
+The `snowflakeId()` method creates a new primary key column with a default name of 'id'.  The `snowflake()` method adds a regular snowflake column which is ideal for creating foreign keys.
+
 ### Automatically generate snowflake ids
 
 Verbs allows for `snowflake_id` auto-generation by default when using most of our [attributes](/docs/technical/attributes).


### PR DESCRIPTION
This PR updates the documentation on snowflake ids to include information about the migration helper methods provided by the `glhd/bits` package.