### PR TITLE
Custom dependency injection implementation

### DIFF
--- a/src/Exceptions/AmbiguousDependencyException.php
+++ b/src/Exceptions/AmbiguousDependencyException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Thunk\Verbs\Exceptions;
+
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+use Thunk\Verbs\Support\NamedDependency;
+use Thunk\Verbs\Support\Reflection\Parameter;
+
+class AmbiguousDependencyException extends InvalidArgumentException
+{
+    public function __construct(Parameter $parameter, Collection $candidates)
+    {
+        // TODO: We might want to link to docs here, although the message is very descriptive
+
+        $variable = '$'.$parameter->getName();
+        $typehint = class_basename($parameter->type()->name());
+
+        $message = "Unable to resolve dependency '{$typehint} {$variable}' because '{$typehint}' is ambiguous.";
+        $message = $this->appendCandidateList($message, $variable, $candidates);
+
+        parent::__construct($message);
+    }
+
+    protected function appendCandidateList(string $message, string $variable, Collection $candidates): string
+    {
+        $options = $candidates
+            ->filter(fn ($candidate) => $candidate instanceof NamedDependency)
+            ->map(fn (NamedDependency $candidate) => "'\${$candidate->name}'");
+
+        if ($options->isNotEmpty()) {
+            $message .= " Did you mean {$options->implode(' or ')} instead of '{$variable}'?";
+        }
+
+        return $message;
+    }
+}

--- a/src/Exceptions/CannotResolveParameter.php
+++ b/src/Exceptions/CannotResolveParameter.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Thunk\Verbs\Exceptions;
+
+use InvalidArgumentException;
+
+class CannotResolveParameter extends InvalidArgumentException {}

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -38,17 +38,13 @@ class Broker implements BrokersEvents
         // NOTE: Any changes to how the dispatcher is called here
         // should also be applied to the `replay` method
 
-        $states = $event->states();
+        Guards::for($event)->check();
 
-        $states->each(fn ($state) => Guards::for($event, $state)->check());
-
-        Guards::for($event, null)->check();
-
-        $states->each(fn ($state) => $this->dispatcher->apply($event, $state));
+        $this->dispatcher->apply($event);
 
         app(Queue::class)->queue($event);
 
-        $this->dispatcher->fired($event, $states);
+        $this->dispatcher->fired($event);
 
         if ($this->commit_immediately || $event instanceof CommitsImmediately) {
             $this->commit();
@@ -93,8 +89,8 @@ class Broker implements BrokersEvents
                         $beforeEach($event);
                     }
 
-                    $event->states()->each(fn ($state) => $this->dispatcher->apply($event, $state));
-                    $this->dispatcher->replay($event, $event->states());
+                    $this->dispatcher->apply($event);
+                    $this->dispatcher->replay($event);
 
                     if ($afterEach) {
                         $afterEach($event);

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -66,7 +66,7 @@ class Broker implements BrokersEvents
         app(StateManager::class)->writeSnapshots();
 
         foreach ($events as $event) {
-            $this->metadata->setLastResults($event, $this->dispatcher->handle($event, $event->states()));
+            $this->metadata->setLastResults($event, $this->dispatcher->handle($event));
         }
 
         return $this->commit();

--- a/src/Lifecycle/Dispatcher.php
+++ b/src/Lifecycle/Dispatcher.php
@@ -75,8 +75,7 @@ class Dispatcher
             return collect();
         }
 
-        return $this->getHandleHooks($event)
-            ->map(fn (Hook $hook) => $hook->handle($this->container, $event));
+        return $this->getHandleHooks($event)->map(fn (Hook $hook) => $hook->handle($this->container, $event));
     }
 
     public function replay(Event $event): void

--- a/src/Lifecycle/Guards.php
+++ b/src/Lifecycle/Guards.php
@@ -51,7 +51,7 @@ class Guards
         }
 
         if (method_exists($this->event, 'failedValidation')) {
-            $this->event->failedValidation($this->state);
+            $this->event->failedValidation($exception);
         }
 
         throw $exception;

--- a/src/Lifecycle/Hook.php
+++ b/src/Lifecycle/Hook.php
@@ -45,7 +45,7 @@ class Hook
         public Closure $callback,
         public array $events = [],
         public array $states = [],
-        public SplObjectStorage $phases = new SplObjectStorage(),
+        public SplObjectStorage $phases = new SplObjectStorage,
         public ?string $name = null,
     ) {}
 

--- a/src/Lifecycle/Hook.php
+++ b/src/Lifecycle/Hook.php
@@ -4,17 +4,16 @@ namespace Thunk\Verbs\Lifecycle;
 
 use Closure;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Support\Str;
 use ReflectionMethod;
 use RuntimeException;
 use SplObjectStorage;
 use Thunk\Verbs\Event;
-use Thunk\Verbs\Metadata;
 use Thunk\Verbs\State;
 use Thunk\Verbs\Support\DependencyResolver;
 use Thunk\Verbs\Support\Reflector;
 use Thunk\Verbs\Support\StateCollection;
 use Thunk\Verbs\Support\Wormhole;
+use WeakMap;
 
 class Hook
 {
@@ -49,7 +48,7 @@ class Hook
         public Closure $callback,
         public array $events = [],
         public array $states = [],
-        public SplObjectStorage $phases = new SplObjectStorage,
+        public SplObjectStorage $phases = new SplObjectStorage(),
         public ?string $name = null,
     ) {}
 
@@ -79,7 +78,7 @@ class Hook
     public function validate(Container $container, Event $event, ?State $state = null): bool
     {
         if ($this->runsInPhase(Phase::Validate)) {
-            return $container->call($this->callback, $this->guessParameters($event, $state)) ?? true;
+            return $this->call($container, $event) ?? true;
         }
 
         throw new RuntimeException('Hook::validate called on a non-validation hook.');
@@ -88,22 +87,21 @@ class Hook
     public function apply(Container $container, Event $event, State $state): void
     {
         if ($this->runsInPhase(Phase::Apply)) {
-            $this->call($container, $event); // FIXME
-            app(Wormhole::class)->warp($event, fn () => $container->call($this->callback, $this->guessParameters($event, $state)));
+            app(Wormhole::class)->warp($event, fn () => $this->call($container, $event));
         }
     }
 
     public function fired(Container $container, Event $event, StateCollection $states): void
     {
         if ($this->runsInPhase(Phase::Fired)) {
-            $container->call($this->callback, $this->guessParameters($event, states: $states));
+            $this->call($container, $event);
         }
     }
 
     public function handle(Container $container, Event $event, StateCollection $states): mixed
     {
         if ($this->runsInPhase(Phase::Handle)) {
-            return $container->call($this->callback, $this->guessParameters($event, states: $states));
+            $this->call($container, $event);
         }
 
         return null;
@@ -112,82 +110,39 @@ class Hook
     public function replay(Container $container, Event $event, StateCollection $states): void
     {
         if ($this->runsInPhase(Phase::Replay)) {
-            app(Wormhole::class)->warp($event, fn () => $container->call($this->callback, $this->guessParameters($event, states: $states)));
+            app(Wormhole::class)->warp($event, fn () => $this->call($container, $event));
         }
     }
 
     protected function call(Container $container, Event $event)
     {
-        $resolver = DependencyResolver::for($this->callback, container: $container);
+        $resolver = DependencyResolver::for($this->callback, container: $container)
+            ->add($event->metadata())
+            ->add($event);
 
-        $states = $event->states();
+        $this->addStatesToResolver($resolver, $event->states());
+
+        return call_user_func_array($this->callback, $resolver());
+    }
+
+    protected function addStatesToResolver(DependencyResolver $resolver, StateCollection $states): DependencyResolver
+    {
+        $added = new WeakMap();
 
         // Add states by alias for named resolution
         foreach ($states->aliasNames() as $name) {
-            $resolver->add($states->get($name), $name);
+            $state = $states->get($name);
+            $added[$state] = true;
+            $resolver->add($state, $name);
         }
 
-        // Then add ALL states regardless of whether they're aliased or not
+        // Then add any other states that do not have aliases
         foreach ($states as $state) {
-            $resolver->add($state);
-        }
-
-        $dependencies = $resolver();
-        dump($dependencies);
-    }
-
-    protected function guessParameters(Event $event, ?State $state = null, ?StateCollection $states = null): array
-    {
-        $metadata = $event->metadata();
-
-        $parameters = [
-            'e' => $event,
-            'event' => $event,
-            $event::class => $event,
-            (string) Str::of($event::class)->classBasename()->snake() => $event,
-            (string) Str::of($event::class)->classBasename()->studly() => $event,
-            'meta' => $metadata,
-            'metadata' => $metadata,
-            'metaData' => $metadata,
-            'meta_data' => $metadata,
-            Metadata::class => $metadata,
-        ];
-
-        if ($state) {
-            $parameters = [
-                ...$parameters,
-                's' => $state,
-                'state' => $state,
-                $state::class => $state,
-                (string) Str::of($state::class)->classBasename()->snake() => $state,
-                (string) Str::of($state::class)->classBasename()->studly() => $state,
-            ];
-        }
-
-        if ($states) {
-            foreach ($states as $state) {
-                $keys = [
-                    $state::class,
-                    (string) Str::of($state::class)->classBasename()->snake(),
-                    (string) Str::of($state::class)->classBasename()->studly(),
-                ];
-
-                // FIXME: We need to throw an ambiguous state exception if a method wants a state that we have 2+ of
-                //        But right now, we'll just null them out
-                if (array_key_exists($state::class, $parameters)) {
-                    $state = null;
-                }
-
-                foreach ($keys as $key) {
-                    $parameters[$key] = $state;
-                }
-            }
-
-            foreach ($states->aliasNames() as $alias) {
-                $parameters[$alias] = $states->get($alias);
+            if (! isset($added[$state])) {
+                $resolver->add($state);
             }
         }
 
-        return $parameters;
+        return $resolver;
     }
 }

--- a/src/Lifecycle/Hook.php
+++ b/src/Lifecycle/Hook.php
@@ -98,7 +98,7 @@ class Hook
     public function handle(Container $container, Event $event): mixed
     {
         if ($this->runsInPhase(Phase::Handle)) {
-            $this->execute($container, $event);
+            return $this->execute($container, $event);
         }
 
         return null;

--- a/src/Lifecycle/SnapshotStore.php
+++ b/src/Lifecycle/SnapshotStore.php
@@ -50,7 +50,7 @@ class SnapshotStore implements StoresSnapshots
         }
 
         return VerbSnapshot::upsert(
-            values: collect($states)->unique()->map($this->formatForWrite(...))->all(),
+            values: collect($states)->map($this->formatForWrite(...))->unique('id')->all(),
             uniqueBy: ['id'],
             update: ['data', 'last_event_id', 'updated_at']
         );

--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -115,12 +115,17 @@ class StateManager
 
     protected function reconstitute(State $state, bool $singleton = false): static
     {
+        // FIXME: Is this OK without specifying a state? It may have more effects than previously,
+        //        but there was an incorrect assumption before that it would only run on that one
+        //        state, which is not true because apply() without arguments was assumed to accept
+        //        all states, so it would run no matter what. Needs discussion!
+
         // When we're replaying, the Broker is in charge of applying the correct events
         // to the State, so we only need to do it *outside* of replays.
         if (! $this->is_replaying) {
             $this->events
                 ->read(state: $state, after_id: $state->last_event_id, singleton: $singleton)
-                ->each(fn (Event $event) => $this->dispatcher->apply($event, $state));
+                ->each(fn (Event $event) => $this->dispatcher->apply($event));
         }
 
         return $this;

--- a/src/Support/DependencyResolver.php
+++ b/src/Support/DependencyResolver.php
@@ -27,7 +27,7 @@ class DependencyResolver
         protected Collection $candidates,
     ) {}
 
-    public function with(mixed $candidate, ?string $name = null): static
+    public function add(mixed $candidate, ?string $name = null): static
     {
         if ($name) {
             $candidate = new NamedDependency($name, $candidate);
@@ -38,12 +38,12 @@ class DependencyResolver
         return $this;
     }
 
-    public function __invoke()
+    public function __invoke(): array
     {
-        $reflect = new ReflectionFunction($this->callback);
-
-        return collect($reflect->getParameters())
-            ->map($this->resolveParameter(...));
+        return array_map(
+            $this->resolveParameter(...),
+            (new ReflectionFunction($this->callback))->getParameters()
+        );
     }
 
     protected function resolveParameter(ReflectionParameter $reflection): mixed

--- a/src/Support/DependencyResolver.php
+++ b/src/Support/DependencyResolver.php
@@ -3,7 +3,7 @@
 namespace Thunk\Verbs\Support;
 
 use Closure;
-use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Collection;
 use ReflectionFunction;
 use ReflectionParameter;
@@ -15,7 +15,7 @@ class DependencyResolver
     public static function for(Closure $callback, ?Collection $candidates = null, ?Container $container = null): static
     {
         return new static(
-            container: $container ?? Container::getInstance(),
+            container: $container ?? \Illuminate\Container\Container::getInstance(),
             callback: $callback,
             candidates: $candidates ?? new Collection(),
         );

--- a/src/Support/DependencyResolver.php
+++ b/src/Support/DependencyResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Thunk\Verbs\Support;
+
+use Closure;
+use Illuminate\Container\Container;
+use Illuminate\Support\Collection;
+use ReflectionFunction;
+use ReflectionParameter;
+use Thunk\Verbs\Exceptions\AmbiguousDependencyException;
+use Thunk\Verbs\Support\Reflection\Parameter;
+
+class DependencyResolver
+{
+    public static function for(Closure $callback, ?Collection $candidates = null, ?Container $container = null): static
+    {
+        return new static(
+            container: $container ?? Container::getInstance(),
+            callback: $callback,
+            candidates: $candidates ?? new Collection(),
+        );
+    }
+
+    public function __construct(
+        protected Container $container,
+        protected Closure $callback,
+        protected Collection $candidates,
+    ) {}
+
+    public function with(mixed $candidate, ?string $name = null): static
+    {
+        if ($name) {
+            $candidate = new NamedDependency($name, $candidate);
+        }
+
+        $this->candidates->push($candidate);
+
+        return $this;
+    }
+
+    public function __invoke()
+    {
+        $reflect = new ReflectionFunction($this->callback);
+
+        return collect($reflect->getParameters())
+            ->map($this->resolveParameter(...));
+    }
+
+    protected function resolveParameter(ReflectionParameter $reflection): mixed
+    {
+        $parameter = new Parameter($reflection);
+
+        $candidates = $this->candidates->filter($parameter->accepts(...));
+
+        $resolved = match ($candidates->count()) {
+            0 => $this->container->make($parameter->type()->name()),
+            1 => $candidates->first(),
+            default => $this->resolveAmbiguousParameter($parameter, $candidates),
+        };
+
+        if ($resolved instanceof NamedDependency) {
+            $resolved = $resolved->value;
+        }
+
+        return $resolved;
+    }
+
+    protected function resolveAmbiguousParameter(Parameter $parameter, Collection $candidates): mixed
+    {
+        $resolved = $candidates->first(
+            fn ($candidate) => $candidate instanceof NamedDependency && $candidate->name === $parameter->name
+        );
+
+        if (! $resolved) {
+            throw new AmbiguousDependencyException($parameter, $candidates);
+        }
+
+        return $resolved;
+    }
+}

--- a/src/Support/DependencyResolver.php
+++ b/src/Support/DependencyResolver.php
@@ -34,7 +34,7 @@ class DependencyResolver
         protected Container $container,
         protected Closure $callback,
     ) {
-        $this->candidates = new Collection();
+        $this->candidates = new Collection;
     }
 
     public function add(mixed $candidate, ?string $name = null): static
@@ -60,7 +60,7 @@ class DependencyResolver
 
     public function addStates(StateCollection $states): static
     {
-        $added = new WeakMap();
+        $added = new WeakMap;
 
         // Add states by alias for named resolution
         foreach ($states->aliasNames() as $name) {

--- a/src/Support/MethodFinder.php
+++ b/src/Support/MethodFinder.php
@@ -66,7 +66,7 @@ class MethodFinder
 
     protected function expectsParameters(ReflectionMethod $method): bool
     {
-        if ($this->types && count($this->types) === 0) {
+        if (! $this->types || $this->types->isEmpty()) {
             return true;
         }
 

--- a/src/Support/NamedDependency.php
+++ b/src/Support/NamedDependency.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Thunk\Verbs\Support;
+
+class NamedDependency
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly mixed $value,
+    ) {}
+}

--- a/src/Support/Reflection/Parameter.php
+++ b/src/Support/Reflection/Parameter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Thunk\Verbs\Support\Reflection;
+
+use Illuminate\Support\Traits\ForwardsCalls;
+use ReflectionParameter;
+use Thunk\Verbs\Support\NamedDependency;
+
+/** @mixin ReflectionParameter */
+class Parameter
+{
+    use ForwardsCalls;
+
+    protected ?Type $type = null;
+
+    public function __construct(
+        public ReflectionParameter $target,
+    ) {}
+
+    public function accepts(mixed $value): bool
+    {
+        if ($value instanceof NamedDependency) {
+            $value = $value->value;
+        }
+
+        return match (true) {
+            $this->type()->isBuiltin() => get_debug_type($value) === $this->type()->name(),
+            default => is_a($value, $this->type()->name(), true),
+        };
+    }
+
+    public function type(): Type
+    {
+        return $this->type ??= new Type($this);
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+        return $this->forwardDecoratedCallTo($this->target, $name, $arguments);
+    }
+
+    public function __get(string $name)
+    {
+        return $this->target->{$name};
+    }
+}

--- a/src/Support/Reflection/Type.php
+++ b/src/Support/Reflection/Type.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Thunk\Verbs\Support\Reflection;
+
+use Illuminate\Support\Traits\ForwardsCalls;
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionUnionType;
+use Thunk\Verbs\Exceptions\CannotResolveParameter;
+
+/** @mixin ReflectionNamedType */
+class Type
+{
+    use ForwardsCalls;
+
+    public ReflectionNamedType $target;
+
+    public function __construct(
+        public Parameter $parameter,
+    ) {
+        if (! $type = $parameter->target->getType()) {
+            throw new CannotResolveParameter('You must provide a parameter type for Verbs to inject.');
+        }
+
+        if ($type instanceof ReflectionIntersectionType || $type instanceof ReflectionUnionType) {
+            throw new CannotResolveParameter('Verbs cannot inject intersection or union types.');
+        }
+
+        $this->target = $this->parameter->target->getType();
+    }
+
+    public function name(): string
+    {
+        $name = $this->target->getName();
+
+        return match ($name) {
+            'self' => $this->parameter->target->getDeclaringClass()->getName(),
+            'parent' => $this->parameter->target->getDeclaringClass()->getParentClass()->getName(),
+            default => $name,
+        };
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+        return $this->forwardDecoratedCallTo($this->target, $name, $arguments);
+    }
+}

--- a/tests/Feature/DependencyInjectionTest.php
+++ b/tests/Feature/DependencyInjectionTest.php
@@ -9,13 +9,15 @@ it('can injects states as expected', function () {
     Verbs::fake();
     $event = DependencyInjectionTestEvent::fire();
     Verbs::commit();
-    expect($event->expectations)->toBeEmpty();
+    expect($event->expectations)->toEqual([]);
 });
 
 it('can inject states of same type into event handle methods by alias', function () {
     Verbs::fake();
     DependencyInjectionTestMultiHandleEvent::commit();
 });
+
+// TODO: How do we handle nullable state_ids
 
 class DependencyInjectionTestEvent extends Event
 {
@@ -67,14 +69,10 @@ class DependencyInjectionTestMultiHandleEvent extends Event
         #[StateId(DependencyInjectionTestState::class)] public ?int $test2_id,
     ) {}
 
-    public function apply(DependencyInjectionTestState $state)
+    public function apply(DependencyInjectionTestState $test1, DependencyInjectionTestState $test2)
     {
-        if ($state->id === $this->test1_id) {
-            $state->name = 'test1';
-        }
-        if ($state->id === $this->test2_id) {
-            $state->name = 'test2';
-        }
+        $test1->name = 'test1';
+        $test2->name = 'test2';
     }
 
     public function handle(DependencyInjectionTestState $test1, DependencyInjectionTestState $test2)

--- a/tests/Unit/DependencyManagerTest.php
+++ b/tests/Unit/DependencyManagerTest.php
@@ -1,21 +1,33 @@
 <?php
 
+use Glhd\Bits\Contracts\MakesSnowflakes;
+use Thunk\Verbs\Exceptions\AmbiguousDependencyException;
 use Thunk\Verbs\State;
 use Thunk\Verbs\Support\DependencyResolver;
 
 it('can resolve parameter types correctly', function () {
-    $callback = function (string $s, int $i, State $one, State $two) {};
+    $callback = function (string $s, int $i, State $one, State $two, MakesSnowflakes $bits) {};
 
     $one = new class extends State {};
     $two = new class extends State {};
+    $bits = app(MakesSnowflakes::class);
 
     $resolver = DependencyResolver::for($callback)
-        ->with($one, 'one')
-        ->with($two, 'two')
-        ->with(1337)
-        ->with('foo');
+        ->add($one, 'one')
+        ->add($two, 'two')
+        ->add($bits)
+        ->add(1337)
+        ->add('foo');
 
-    $resolved = $resolver();
-
-    $this->assertSame(['foo', 1337, $one, $two], $resolved->all());
+    $this->assertSame(['foo', 1337, $one, $two, $bits], $resolver());
 });
+
+it('throws an exception if dependencies are ambiguous', function () {
+    $callback = function (State $a, State $b) {};
+
+    $resolver = DependencyResolver::for($callback)
+        ->add(new class extends State {}, 'state1')
+        ->add(new class extends State {}, 'state2');
+
+    $resolver();
+})->throws(AmbiguousDependencyException::class);

--- a/tests/Unit/DependencyManagerTest.php
+++ b/tests/Unit/DependencyManagerTest.php
@@ -22,6 +22,20 @@ it('can resolve parameter types correctly', function () {
     $this->assertSame(['foo', 1337, $one, $two, $bits], $resolver());
 });
 
+it('can resolve a dependency with multiple names', function () {
+    $callback = function (State $dep, State $two) {};
+
+    $one = new class extends State {};
+    $two = new class extends State {};
+
+    $resolver = DependencyResolver::for($callback)
+        ->add($one, 'dep')
+        ->add($one, 'one')
+        ->add($two, 'two');
+
+    $this->assertSame([$one, $two], $resolver());
+});
+
 it('throws an exception if dependencies are ambiguous', function () {
     $callback = function (State $a, State $b) {};
 

--- a/tests/Unit/DependencyManagerTest.php
+++ b/tests/Unit/DependencyManagerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Thunk\Verbs\State;
+use Thunk\Verbs\Support\DependencyResolver;
+
+it('can resolve parameter types correctly', function () {
+    $callback = function (string $s, int $i, State $one, State $two) {};
+
+    $one = new class extends State {};
+    $two = new class extends State {};
+
+    $resolver = DependencyResolver::for($callback)
+        ->with($one, 'one')
+        ->with($two, 'two')
+        ->with(1337)
+        ->with('foo');
+
+    $resolved = $resolver();
+
+    $this->assertSame(['foo', 1337, $one, $two], $resolved->all());
+});

--- a/tests/Unit/StateIdTest.php
+++ b/tests/Unit/StateIdTest.php
@@ -65,8 +65,9 @@ class StateIdTestEvent extends Event
     #[StateId(StateIdTestState::class, autofill: false)]
     public ?int $other_state_id = null;
 
-    public function apply(StateIdTestState $state)
+    public function apply(StateIdTestState $state, StateIdTestState $other_state)
     {
         $state->acknowledged = true;
+        $other_state->acknowledged = true;
     }
 }


### PR DESCRIPTION
Right now, we rely on the Laravel container to handle DI, which means that there is some Verbs-specific logic that is hard to implement. This PR introduces a new `DependencyResolver` class that handles resolving all dependencies in your event hooks (`validate`, `apply`, etc). Owning the dependency resolution lets us handle events attached to multiple states considerably easier.

### Breaking Change

The major consequence of this change is now all hooks can be called **just once**, and Verbs will figure out which dependency you want based on the following criteria:

1. If you typehint something that Verbs isn't managing (ie. not a `State` or `Event`), we will resolve thru the Container normally
2. If you typehint something that only has one "candidate" match, we will inject it regardless of variable name (eg. if you have an event that fires on a `UserState` and you typehint `apply(UserState $foo)` we will inject the `UserState` associated with the event as the `$foo` parameter)
3. If you typehint something that has two+ candidates, we will match on name and throw an exception if that is ambiguous (eg. if you have an event that fires on two `UsersState`s, say `$actor_id` and `$target_id`, then you must use `UserState $actor` and `UserState $target` to tell Verbs which you mean)

Previously, if you had an event that fired on multiple states, hooks might be called multiple times:

#### Before
```php
class BallotCast extends Event
{
  #[StateId(UserState::class)]
  public int $actor_id;

  #[StateId(UserState::class)]
  public int $target_id;

  public function apply(UserState $user) {
    // This gets called twice, once with the actor and once with 
    // the target, so we need to check before applying
    if ($user->id === $this->actor_id) {
      $user->has_cast_vote = true;
    }
    if ($user->id === $this->target_id) {
      $user->votes_received++;
    }
  }
}
```

#### After
```php
class BallotCast extends Event
{
  #[StateId(UserState::class)]
  public int $actor_id;

  #[StateId(UserState::class)]
  public int $target_id;

  public function apply(UserState $actor, UserState $target) {
    $actor->has_cast_vote = true;
    $target->votes_received++;
  }
}
```

I think this change in API is **significantly better** and worth the BC break, but it's worth noting.