### PR TITLE
fix error when the event data array doesn't have an item at position 0

### DIFF
--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -159,7 +159,7 @@ class VerbsServiceProvider extends PackageServiceProvider
 
         // Hook into Laravel event dispatcher
         $this->app->make(LaravelDispatcher::class)
-            ->listen('*', fn (string $name, array $data) => $this->handleEvent($data[0]));
+            ->listen('*', fn (string $name, array $data) => $this->handleEvent($data[0] ?? null));
     }
 
     protected function handleEvent($event = null)


### PR DESCRIPTION
Problem is described in the issue #157 

fixes #157 