### PR TITLE
Store new snapshots on replay.

### DIFF
--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -20,8 +20,7 @@ class Broker implements BrokersEvents
         protected MetadataManager $metadata,
         protected EventQueue $queue,
         protected StateManager $states,
-    ) {
-    }
+    ) {}
 
     public function fireIfValid(Event $event): ?Event
     {
@@ -96,7 +95,7 @@ class Broker implements BrokersEvents
                     if ($afterEach) {
                         $afterEach($event);
                     }
-                    
+
                     $this->states->writeSnapshots();
                     $this->states->prune();
                 });

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -20,7 +20,8 @@ class Broker implements BrokersEvents
         protected MetadataManager $metadata,
         protected EventQueue $queue,
         protected StateManager $states,
-    ) {}
+    ) {
+    }
 
     public function fireIfValid(Event $event): ?Event
     {
@@ -100,6 +101,7 @@ class Broker implements BrokersEvents
                 });
         } finally {
             $this->states->setReplaying(false);
+            $this->states->writeSnapshots();
             $this->is_replaying = false;
         }
     }

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -20,7 +20,8 @@ class Broker implements BrokersEvents
         protected MetadataManager $metadata,
         protected EventQueue $queue,
         protected StateManager $states,
-    ) {}
+    ) {
+    }
 
     public function fireIfValid(Event $event): ?Event
     {
@@ -95,12 +96,12 @@ class Broker implements BrokersEvents
                     if ($afterEach) {
                         $afterEach($event);
                     }
-
+                    
+                    $this->states->writeSnapshots();
                     $this->states->prune();
                 });
         } finally {
             $this->states->setReplaying(false);
-            $this->states->writeSnapshots();
             $this->is_replaying = false;
         }
     }

--- a/tests/Feature/ReplayCommandTest.php
+++ b/tests/Feature/ReplayCommandTest.php
@@ -111,10 +111,10 @@ it('creates new snapshots when replaying', function () {
     $snapshot1 = VerbSnapshot::firstWhere('state_id', $state1_id);
     $snapshot2 = VerbSnapshot::firstWhere('state_id', $state2_id);
 
-    expect($snapshot1->data)->toBe(json_encode(['count' => 1]));
+    expect($snapshot1->data)->toBe(json_encode(['count' => 1], JSON_PRETTY_PRINT));
     expect($snapshot1->created_at)->toEqual(CarbonImmutable::parse('2024-04-01 12:00:00'));
 
-    expect($snapshot2->data)->toBe(json_encode(['count' => 3]));
+    expect($snapshot2->data)->toBe(json_encode(['count' => 3], JSON_PRETTY_PRINT));
     expect($snapshot2->created_at)->toEqual(CarbonImmutable::parse('2024-04-01 12:00:00'));
 
     Carbon::setTestNow('2024-05-15 18:00:00');
@@ -130,10 +130,10 @@ it('creates new snapshots when replaying', function () {
     $snapshot1 = VerbSnapshot::firstWhere('state_id', $state1_id);
     $snapshot2 = VerbSnapshot::firstWhere('state_id', $state2_id);
 
-    expect($snapshot1->data)->toBe(json_encode(['count' => 1]));
+    expect($snapshot1->data)->toBe(json_encode(['count' => 1], JSON_PRETTY_PRINT));
     expect($snapshot1->created_at)->toEqual(CarbonImmutable::parse('2024-05-15 18:00:00'));
 
-    expect($snapshot2->data)->toBe(json_encode(['count' => 3]));
+    expect($snapshot2->data)->toBe(json_encode(['count' => 3], JSON_PRETTY_PRINT));
     expect($snapshot2->created_at)->toEqual(CarbonImmutable::parse('2024-05-15 18:00:00'));
 });
 

--- a/tests/Feature/ReplayCommandTest.php
+++ b/tests/Feature/ReplayCommandTest.php
@@ -110,10 +110,10 @@ it('creates new snapshots when replaying', function () {
     $snapshot1 = VerbSnapshot::firstWhere('state_id', $state1_id);
     $snapshot2 = VerbSnapshot::firstWhere('state_id', $state2_id);
 
-    expect($snapshot1->data)->toBe(json_encode(['count' => 1], JSON_PRETTY_PRINT));
+    expect(json_decode($snapshot1->data)->count)->toBe(1);
     expect($snapshot1->created_at)->toEqual(CarbonImmutable::parse('2024-04-01 12:00:00'));
 
-    expect($snapshot2->data)->toBe(json_encode(['count' => 3], JSON_PRETTY_PRINT));
+    expect(json_decode($snapshot2->data)->count)->toBe(3);
     expect($snapshot2->created_at)->toEqual(CarbonImmutable::parse('2024-04-01 12:00:00'));
 
     Carbon::setTestNow('2024-05-15 18:00:00');
@@ -129,10 +129,10 @@ it('creates new snapshots when replaying', function () {
     $snapshot1 = VerbSnapshot::firstWhere('state_id', $state1_id);
     $snapshot2 = VerbSnapshot::firstWhere('state_id', $state2_id);
 
-    expect($snapshot1->data)->toBe(json_encode(['count' => 1], JSON_PRETTY_PRINT));
+    expect(json_decode($snapshot1->data)->count)->toBe(1);
     expect($snapshot1->created_at)->toEqual(CarbonImmutable::parse('2024-05-15 18:00:00'));
 
-    expect($snapshot2->data)->toBe(json_encode(['count' => 3], JSON_PRETTY_PRINT));
+    expect(json_decode($snapshot2->data)->count)->toBe(3);
     expect($snapshot2->created_at)->toEqual(CarbonImmutable::parse('2024-05-15 18:00:00'));
 });
 
@@ -142,7 +142,8 @@ class ReplayCommandTestEvent extends Event
         public int $add = 0,
         public int $subtract = 0,
         #[StateId(ReplayCommandTestState::class)] public ?int $state_id = null,
-    ) {}
+    ) {
+    }
 
     public function apply(ReplayCommandTestState $state)
     {
@@ -169,7 +170,8 @@ class ReplayCommandTestWormholeEvent extends Event
 {
     public function __construct(
         #[StateId(ReplayCommandTestWormholeState::class)] public ?int $state_id = null
-    ) {}
+    ) {
+    }
 
     public function apply(ReplayCommandTestWormholeState $state): void
     {

--- a/tests/Feature/ReplayCommandTest.php
+++ b/tests/Feature/ReplayCommandTest.php
@@ -142,8 +142,7 @@ class ReplayCommandTestEvent extends Event
         public int $add = 0,
         public int $subtract = 0,
         #[StateId(ReplayCommandTestState::class)] public ?int $state_id = null,
-    ) {
-    }
+    ) {}
 
     public function apply(ReplayCommandTestState $state)
     {
@@ -170,8 +169,7 @@ class ReplayCommandTestWormholeEvent extends Event
 {
     public function __construct(
         #[StateId(ReplayCommandTestWormholeState::class)] public ?int $state_id = null
-    ) {
-    }
+    ) {}
 
     public function apply(ReplayCommandTestWormholeState $state): void
     {

--- a/tests/Feature/ReplayCommandTest.php
+++ b/tests/Feature/ReplayCommandTest.php
@@ -1,12 +1,14 @@
 <?php
 
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Carbon;
 use Thunk\Verbs\Attributes\Autodiscovery\StateId;
 use Thunk\Verbs\Commands\ReplayCommand;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Facades\Id;
 use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\Lifecycle\StateManager;
+use Thunk\Verbs\Models\VerbSnapshot;
 use Thunk\Verbs\State;
 
 beforeEach(function () {
@@ -87,13 +89,62 @@ it('uses the original event times when replaying', function () {
         ->toBe(CarbonImmutable::parse('2024-04-01 12:00:00')->unix());
 });
 
+
+it('creates new snapshots when replaying', function () {
+    Carbon::setTestNow('2024-04-01 12:00:00');
+
+    $state1_id = Id::make();
+    $state2_id = Id::make();
+
+    // State 1
+    ReplayCommandTestEvent::fire(add: 2, subtract: 0, state_id: $state1_id); // 2
+    ReplayCommandTestEvent::fire(add: 0, subtract: 1, state_id: $state1_id); // 1
+
+    // State 2
+    ReplayCommandTestEvent::fire(add: 5, subtract: 2, state_id: $state2_id); // 3
+    ReplayCommandTestEvent::fire(add: 2, subtract: 2, state_id: $state2_id); // 3
+
+    Verbs::commit();
+
+    expect(VerbSnapshot::count())->toBe(2);
+
+    $snapshot1 = VerbSnapshot::firstWhere('state_id', $state1_id);
+    $snapshot2 = VerbSnapshot::firstWhere('state_id', $state2_id);
+
+    expect($snapshot1->data)->toBe(json_encode(['count' => 1]));
+    expect($snapshot1->created_at)->toEqual(CarbonImmutable::parse('2024-04-01 12:00:00'));
+
+    expect($snapshot2->data)->toBe(json_encode(['count' => 3]));
+    expect($snapshot2->created_at)->toEqual(CarbonImmutable::parse('2024-04-01 12:00:00'));
+
+    Carbon::setTestNow('2024-05-15 18:00:00');
+
+    $GLOBALS['replay_test_counts'] = [];
+    $GLOBALS['handle_count'] = 1337;
+
+    config(['app.env' => 'testing']);
+    $this->artisan(ReplayCommand::class);
+
+    expect(VerbSnapshot::count())->toBe(2);
+
+    $snapshot1 = VerbSnapshot::firstWhere('state_id', $state1_id);
+    $snapshot2 = VerbSnapshot::firstWhere('state_id', $state2_id);
+
+    expect($snapshot1->data)->toBe(json_encode(['count' => 1]));
+    expect($snapshot1->created_at)->toEqual(CarbonImmutable::parse('2024-05-15 18:00:00'));
+
+    expect($snapshot2->data)->toBe(json_encode(['count' => 3]));
+    expect($snapshot2->created_at)->toEqual(CarbonImmutable::parse('2024-05-15 18:00:00'));
+});
+
 class ReplayCommandTestEvent extends Event
 {
     public function __construct(
         public int $add = 0,
         public int $subtract = 0,
         #[StateId(ReplayCommandTestState::class)] public ?int $state_id = null,
-    ) {}
+    ) {
+    }
 
     public function apply(ReplayCommandTestState $state)
     {
@@ -120,7 +171,8 @@ class ReplayCommandTestWormholeEvent extends Event
 {
     public function __construct(
         #[StateId(ReplayCommandTestWormholeState::class)] public ?int $state_id = null
-    ) {}
+    ) {
+    }
 
     public function apply(ReplayCommandTestWormholeState $state): void
     {


### PR DESCRIPTION
Previously replaying events wiped out the snapshots table and didn't rewrite the snapshots at the end.

Now we rewrite the snapshots.

This is considered good.