### PR TITLE
Use "snapshot_id" as ephemeral key rather than "id"

### DIFF
--- a/src/Lifecycle/SnapshotStore.php
+++ b/src/Lifecycle/SnapshotStore.php
@@ -66,7 +66,7 @@ class SnapshotStore implements StoresSnapshots
     protected function formatForWrite(State $state): array
     {
         return [
-            'id' => $this->metadata->getEphemeral($state, 'id', snowflake_id()),
+            'id' => $this->metadata->getEphemeral($state, 'snapshot_id', snowflake_id()),
             'state_id' => Id::from($state->id),
             'type' => $state::class,
             'data' => $this->serializer->serialize($state),

--- a/src/Models/VerbSnapshot.php
+++ b/src/Models/VerbSnapshot.php
@@ -33,7 +33,7 @@ class VerbSnapshot extends Model
         $this->state->id = $this->state_id;
         $this->state->last_event_id = $this->last_event_id;
 
-        app(MetadataManager::class)->setEphemeral($this->state, 'id', $this->id);
+        app(MetadataManager::class)->setEphemeral($this->state, 'snapshot_id', $this->id);
 
         return $this->state;
     }


### PR DESCRIPTION
Right now we're storing the snapshot's ID as the "id" ephemeral metadata on states. Really, this is the snapshot ID. This PR just fixes that name.