### PR TITLE
Allow for eager loading models

### DIFF
--- a/src/Attributes/Autodiscovery/AppliesToState.php
+++ b/src/Attributes/Autodiscovery/AppliesToState.php
@@ -24,22 +24,24 @@ class AppliesToState extends StateDiscoveryAttribute
         }
     }
 
-    public function discoverState(Event $event, StateManager $manager): array
+    public function discoverState(Event $event, StateManager $manager): State|array
     {
         $property = $this->getStateIdProperty($event);
         $id = $event->{$property};
+
+        if (! is_array($id)) {
+            $this->alias ??= $this->inferAliasFromVariableName($property);
+        }
 
         // If the ID hasn't been set yet, we'll automatically set one
         if ($id === null && $this->autofill) {
             $id = snowflake_id();
             $event->{$property} = $id;
+
+            return $manager->make($id, $this->state_type);
         }
 
         // TODO: Check type of data
-
-        if (! is_array($id)) {
-            $this->alias ??= $this->inferAliasFromVariableName($property);
-        }
 
         return collect(Arr::wrap($id))
             ->map(fn ($id) => $manager->load($id, $this->state_type))

--- a/src/Attributes/Autodiscovery/StateId.php
+++ b/src/Attributes/Autodiscovery/StateId.php
@@ -26,9 +26,11 @@ class StateId extends StateDiscoveryAttribute
     public function discoverState(Event $event, StateManager $manager): State|array
     {
         $id = $this->property->getValue($event);
+        $property_name = $this->property->getName();
+        $meta = $event->metadata();
 
         if (! is_array($id)) {
-            $this->alias ??= $this->inferAliasFromVariableName($this->property->getName());
+            $this->alias ??= $this->inferAliasFromVariableName($property_name);
         }
 
         // If the ID hasn't been set yet, we'll automatically set one
@@ -36,17 +38,19 @@ class StateId extends StateDiscoveryAttribute
             $id = snowflake_id();
             $this->property->setValue($event, $id);
 
+            $autofilled = $meta->get('autofilled', []);
+            $autofilled[$property_name] = true;
+            $meta->put('autofilled', $autofilled);
+
             return $manager->make($id, $this->state_type);
         }
 
-        // If we allowed autofill, then we can assume that this creates a new state.
-        // This prevents having to try to load a snapshot that we know does not exist.
-        if ($this->autofill && $this->property->getType()->allowsNull()) {
+        // If we autofilled the value when it first fired, then we know this is the
+        // first event for that given state, and we don't need to try to load it
+        if ($meta->get("autofilled.{$property_name}", false)) {
             return $manager->make($id, $this->state_type);
         }
 
-        return collect(Arr::wrap($id))
-            ->map(fn ($id) => $manager->load($id, $this->state_type))
-            ->all();
+        return array_map(fn ($id) => $manager->load($id, $this->state_type), Arr::wrap($id));
     }
 }

--- a/src/Attributes/Autodiscovery/StateId.php
+++ b/src/Attributes/Autodiscovery/StateId.php
@@ -23,18 +23,20 @@ class StateId extends StateDiscoveryAttribute
         }
     }
 
-    public function discoverState(Event $event, StateManager $manager): array
+    public function discoverState(Event $event, StateManager $manager): State|array
     {
         $id = $this->property->getValue($event);
+
+        if (! is_array($id)) {
+            $this->alias ??= $this->inferAliasFromVariableName($this->property->getName());
+        }
 
         // If the ID hasn't been set yet, we'll automatically set one
         if ($id === null && $this->autofill) {
             $id = snowflake_id();
             $this->property->setValue($event, $id);
-        }
 
-        if (! is_array($id)) {
-            $this->alias ??= $this->inferAliasFromVariableName($this->property->getName());
+            return $manager->make($id, $this->state_type);
         }
 
         return collect(Arr::wrap($id))

--- a/src/Attributes/Autodiscovery/StateId.php
+++ b/src/Attributes/Autodiscovery/StateId.php
@@ -39,6 +39,12 @@ class StateId extends StateDiscoveryAttribute
             return $manager->make($id, $this->state_type);
         }
 
+        // If we allowed autofill, then we can assume that this creates a new state.
+        // This prevents having to try to load a snapshot that we know does not exist.
+        if ($this->autofill && $this->property->getType()->allowsNull()) {
+            return $manager->make($id, $this->state_type);
+        }
+
         return collect(Arr::wrap($id))
             ->map(fn ($id) => $manager->load($id, $this->state_type))
             ->all();

--- a/src/Attributes/Projection/EagerLoad.php
+++ b/src/Attributes/Projection/EagerLoad.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Thunk\Verbs\Attributes\Projection;
+
+use Attribute;
+use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
+use ReflectionNamedType;
+use ReflectionProperty;
+use Str;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Exceptions\AttributeNotAllowed;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class EagerLoad
+{
+    public function __construct(
+        protected ?string $id_attribute = null,
+    ) {}
+
+    public function handle(ReflectionProperty $property, Event $event): array
+    {
+        if ($property->isPublic() || $property->isStatic()) {
+            throw new AttributeNotAllowed('You can only eager-load protected instance properties.');
+        }
+
+        $type = $property->getType();
+        if (! $type instanceof ReflectionNamedType) {
+            throw new AttributeNotAllowed('You can only apply #[EagerLoad] to properties with a type hint.');
+        }
+
+        $class_name = $type->getName();
+        if (! is_a($class_name, Model::class, true)) {
+            throw new AttributeNotAllowed('You can only eager load eloquent models.');
+        }
+
+        $name = $property->getName();
+        $this->id_attribute ??= Str::snake($name).'_id';
+
+        if (! property_exists($event, $this->id_attribute)) {
+            $event_class = class_basename($event);
+            throw new InvalidArgumentException("Unable to find property '{$this->id_attribute}' on '{$event_class}'.");
+        }
+
+        return [$class_name, $event, $this->id_attribute, $name];
+    }
+}

--- a/src/Exceptions/AttributeNotAllowed.php
+++ b/src/Exceptions/AttributeNotAllowed.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Thunk\Verbs\Exceptions;
+
+use LogicException;
+
+class AttributeNotAllowed extends LogicException {}

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -2,12 +2,14 @@
 
 namespace Thunk\Verbs\Lifecycle;
 
+use Illuminate\Support\Enumerable;
 use Thunk\Verbs\CommitsImmediately;
 use Thunk\Verbs\Contracts\BrokersEvents;
 use Thunk\Verbs\Contracts\StoresEvents;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Exceptions\EventNotValid;
 use Thunk\Verbs\Lifecycle\Queue as EventQueue;
+use Thunk\Verbs\Support\EagerLoader;
 
 class Broker implements BrokersEvents
 {
@@ -68,6 +70,8 @@ class Broker implements BrokersEvents
         $this->states->writeSnapshots();
         $this->states->prune();
 
+        EagerLoader::load(...$events);
+
         foreach ($events as $event) {
             $this->metadata->setLastResults($event, $this->dispatcher->handle($event));
         }
@@ -82,27 +86,28 @@ class Broker implements BrokersEvents
         try {
             $this->states->reset(include_storage: true);
 
-            $iteration = 0;
-
             app(StoresEvents::class)->read()
-                ->each(function (Event $event) use ($beforeEach, $afterEach, &$iteration) {
-                    $this->states->setReplaying(true);
+                ->chunk(500)
+                ->each(function (Enumerable $events) use ($beforeEach, $afterEach) {
+                    EagerLoader::load(...$events);
 
-                    if ($beforeEach) {
-                        $beforeEach($event);
-                    }
+                    $events->each(function (Event $event) use ($beforeEach, $afterEach) {
+                        $this->states->setReplaying(true);
 
-                    $this->dispatcher->apply($event);
-                    $this->dispatcher->replay($event);
+                        if ($beforeEach) {
+                            $beforeEach($event);
+                        }
 
-                    if ($afterEach) {
-                        $afterEach($event);
-                    }
+                        $this->dispatcher->apply($event);
+                        $this->dispatcher->replay($event);
 
-                    if ($iteration++ % 500 === 0) {
-                        $this->states->writeSnapshots();
-                        $this->states->prune();
-                    }
+                        if ($afterEach) {
+                            $afterEach($event);
+                        }
+                    });
+
+                    $this->states->writeSnapshots();
+                    $this->states->prune();
                 });
         } finally {
             $this->states->writeSnapshots();

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -82,8 +82,10 @@ class Broker implements BrokersEvents
         try {
             $this->states->reset(include_storage: true);
 
+            $iteration = 0;
+
             app(StoresEvents::class)->read()
-                ->each(function (Event $event) use ($beforeEach, $afterEach) {
+                ->each(function (Event $event) use ($beforeEach, $afterEach, &$iteration) {
                     $this->states->setReplaying(true);
 
                     if ($beforeEach) {
@@ -97,10 +99,14 @@ class Broker implements BrokersEvents
                         $afterEach($event);
                     }
 
-                    $this->states->writeSnapshots();
-                    $this->states->prune();
+                    if ($iteration++ % 500 === 0) {
+                        $this->states->writeSnapshots();
+                        $this->states->prune();
+                    }
                 });
         } finally {
+            $this->states->writeSnapshots();
+            $this->states->prune();
             $this->states->setReplaying(false);
             $this->is_replaying = false;
         }

--- a/src/Lifecycle/EventStore.php
+++ b/src/Lifecycle/EventStore.php
@@ -59,12 +59,14 @@ class EventStore implements StoresEvents
                 ->where('state_type', $state::class)
                 ->when($after_id, fn (Builder $query) => $query->whereRelation('event', 'id', '>', Id::from($after_id)))
                 ->lazyById()
+                ->remember()
                 ->map(fn (VerbStateEvent $pivot) => $pivot->event);
         }
 
         return VerbEvent::query()
             ->when($after_id, fn (Builder $query) => $query->where('id', '>', Id::from($after_id)))
-            ->lazyById();
+            ->lazyById()
+            ->remember();
     }
 
     /** @param  Event[]  $events */

--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -4,6 +4,7 @@ namespace Thunk\Verbs\Lifecycle;
 
 use Glhd\Bits\Bits;
 use Ramsey\Uuid\UuidInterface;
+use ReflectionClass;
 use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Contracts\StoresEvents;
 use Thunk\Verbs\Contracts\StoresSnapshots;
@@ -48,11 +49,9 @@ class StateManager
                 throw new UnexpectedValueException(sprintf('Expected State <%d> to be of type "%s" but got "%s"', $id, class_basename($type), class_basename($state)));
             }
         } else {
-            $state = $type::make();
-            $state->id = $id;
+            $state = $this->make($id, $type);
         }
 
-        $this->remember($state);
         $this->reconstitute($state);
 
         return $state;
@@ -77,6 +76,24 @@ class StateManager
         $this->reconstitute($state, singleton: true);
 
         return $state;
+    }
+
+    /**
+     * @template TState of State
+     *
+     * @param  class-string<TState>  $type
+     * @return TState
+     */
+    public function make(Bits|UuidInterface|AbstractUid|int|string $id, string $type): State
+    {
+        // State::__construct() auto-registers the state with the StateManager,
+        // so we need to skip the constructor until we've already set the ID.
+
+        $state = (new ReflectionClass($type))->newInstanceWithoutConstructor();
+        $state->id = Id::from($id);
+        $state->__construct();
+
+        return $this->remember($state);
     }
 
     public function writeSnapshots(): bool

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -11,8 +11,6 @@ class Metadata implements ArrayAccess
 
     public function __construct(array $data = [])
     {
-        $this->extra = new Collection;
-
         $this->merge($data);
     }
 
@@ -39,26 +37,36 @@ class Metadata implements ArrayAccess
 
     public function __get(string $name)
     {
+        $this->extra ??= new Collection();
+
         return $this->extra->get($name);
     }
 
     public function __set(string $name, $value): void
     {
+        $this->extra ??= new Collection();
+
         $this->extra->put($name, $value);
     }
 
     public function __isset(string $name): bool
     {
+        $this->extra ??= new Collection();
+
         return $this->extra->has($name);
     }
 
     public function __unset(string $name): void
     {
+        $this->extra ??= new Collection();
+
         $this->extra->forget($name);
     }
 
     public function __sleep(): array
     {
+        $this->extra ??= new Collection();
+
         return $this->extra->toArray();
     }
 

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -37,35 +37,35 @@ class Metadata implements ArrayAccess
 
     public function __get(string $name)
     {
-        $this->extra ??= new Collection();
+        $this->extra ??= new Collection;
 
         return $this->extra->get($name);
     }
 
     public function __set(string $name, $value): void
     {
-        $this->extra ??= new Collection();
+        $this->extra ??= new Collection;
 
         $this->extra->put($name, $value);
     }
 
     public function __isset(string $name): bool
     {
-        $this->extra ??= new Collection();
+        $this->extra ??= new Collection;
 
         return $this->extra->has($name);
     }
 
     public function __unset(string $name): void
     {
-        $this->extra ??= new Collection();
+        $this->extra ??= new Collection;
 
         $this->extra->forget($name);
     }
 
     public function __sleep(): array
     {
-        $this->extra ??= new Collection();
+        $this->extra ??= new Collection;
 
         return $this->extra->toArray();
     }

--- a/src/State.php
+++ b/src/State.php
@@ -30,11 +30,7 @@ abstract class State implements UrlRoutable
             $args = $args[0];
         }
 
-        $state = app(Serializer::class)->deserialize(static::class, $args, call_constructor: true);
-
-        app(StateManager::class)->register($state);
-
-        return $state;
+        return app(Serializer::class)->deserialize(static::class, $args, call_constructor: true);
     }
 
     /** @return StateFactory<static> */

--- a/src/Support/EagerLoader.php
+++ b/src/Support/EagerLoader.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Thunk\Verbs\Support;
+
+use Arr;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use ReflectionClass;
+use ReflectionProperty;
+use Thunk\Verbs\Attributes\Projection\EagerLoad;
+use Thunk\Verbs\Event;
+
+class EagerLoader
+{
+    public static function load(Event ...$events)
+    {
+        return (new static($events))();
+    }
+
+    public function __construct(
+        /** @var Event[] */
+        protected array $events,
+    ) {}
+
+    public function __invoke()
+    {
+        $discovered = collect($this->events)
+            ->map($this->discover(...))
+            ->reduce(function (array $map, Collection $discovered) {
+                foreach ($discovered as [$class_name, $event, $id_property, $target_property]) {
+                    $map['load'][$class_name][] = $event->{$id_property};
+                    $map['fill'][$class_name][$event->{$id_property}][] = [$event, $target_property];
+                }
+
+                return $map;
+            }, ['load' => [], 'fill' => []]);
+
+        /** @var class-string<Model> $class_name */
+        foreach ($discovered['load'] as $class_name => $keys) {
+            $class_name::query()
+                ->whereIn((new $class_name)->getKeyName(), $keys)
+                ->eachById(function (Model $model) use ($discovered) {
+                    foreach ($discovered['fill'][$model::class][$model->getKey()] as [$event, $target_property]) {
+                        // This let's us set the property even if it's protected
+                        (fn () => $this->{$target_property} = clone $model)(...)->call($event);
+                    }
+                });
+        }
+    }
+
+    protected function discover(Event $event): Collection
+    {
+        return collect((new ReflectionClass($event))->getProperties())
+            ->map(function (ReflectionProperty $property) use ($event) {
+                $attribute = Arr::first($property->getAttributes(EagerLoad::class));
+
+                return $attribute?->newInstance()->handle($property, $event);
+            })
+            ->filter()
+            ->values();
+    }
+}

--- a/tests/Feature/EagerLoadingTest.php
+++ b/tests/Feature/EagerLoadingTest.php
@@ -19,7 +19,7 @@ it('identifies the correct data when calling the attribute', function () {
         ->filter()
         ->values();
 
-    expect($attrs->all())->toBe([[TestEagerLoadingModel::class, 1337]]);
+    expect($attrs->all())->toBe([[TestEagerLoadingModel::class, $event, 'test_model_id', 'test_model']]);
 });
 
 it('eager-loads models for events', function () {

--- a/tests/Feature/EagerLoadingTest.php
+++ b/tests/Feature/EagerLoadingTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Thunk\Verbs\Attributes\Projection\EagerLoad;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Support\EagerLoader;
+
+it('identifies the correct data when calling the attribute', function () {
+    $event = new TestEagerLoadingEvent(1337);
+
+    $attrs = collect((new ReflectionClass($event))->getProperties())
+        ->map(function (ReflectionProperty $property) use ($event) {
+            $attribute = Arr::first($property->getAttributes(EagerLoad::class));
+
+            return $attribute?->newInstance()->handle($property, $event);
+        })
+        ->filter()
+        ->values();
+
+    expect($attrs->all())->toBe([[TestEagerLoadingModel::class, 1337]]);
+});
+
+it('eager-loads models for events', function () {
+    TestEagerLoadingModel::migrate();
+
+    $model1 = TestEagerLoadingModel::create(['id' => 1337, 'name' => 'test 1']);
+    $model2 = TestEagerLoadingModel::create(['id' => 9876, 'name' => 'test 2']);
+
+    $event1 = new TestEagerLoadingEvent(1337);
+    $event2 = new TestEagerLoadingEvent(9876);
+
+    EagerLoader::load($event1, $event2);
+
+    expect($event1->getTestModel()->toArray())->toBe($model1->toArray())
+        ->and($event2->getTestModel()->toArray())->toBe($model2->toArray());
+});
+
+class TestEagerLoadingEvent extends Event
+{
+    public function __construct(
+        public int $test_model_id,
+    ) {}
+
+    #[EagerLoad]
+    protected ?TestEagerLoadingModel $test_model = null;
+
+    public function getTestModel(): ?TestEagerLoadingModel
+    {
+        return $this->test_model;
+    }
+}
+
+class TestEagerLoadingModel extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'test_eager_loading';
+
+    public static function migrate()
+    {
+        Schema::create('test_eager_loading', function (Blueprint $table) {
+            $table->snowflakeId();
+            $table->string('name')->nullable();
+        });
+    }
+}


### PR DESCRIPTION
Many events create or update models in their `handle()` method, and up until now, this could cause an N+1 issue if you were operating on a lot of events that all interact with the same model at the same time (either batch operations or replays).

This introduces a new `#[EagerLoad]` attribute that you can add to any protected model property of an event (they must be protected because the model shouldn't be serialized with the event data).

For example:

```php
class UserPromotedToManager extends Event
{
  #[StateId(UserState::class)]
  public int $user_id;

  #[EagerLoad]
  protected User $user;

  public function handle()
  {
    // If the user wasn't eager-loaded, load it lazily
    $this->user ??= User::find($this->user_id);

    $this->user->update(['role' => 'manager']);
  }
}
```
