### PR TITLE
Adds configurable database connections

### DIFF
--- a/config/verbs.php
+++ b/config/verbs.php
@@ -68,11 +68,11 @@ return [
 
     /*
    |--------------------------------------------------------------------------
-   | Table Names
+   | Connection Names
    |--------------------------------------------------------------------------
    |
-   | By default, Verbs prefixes all of its table names with "verb_". However, you
-   | may wish to customize these table names to better fit your application.
+   | By default, Verbs will use your default database connection, However, you may
+   | wish to customize these connection names to better fit your application.
    |
    */
     'connections' => [

--- a/config/verbs.php
+++ b/config/verbs.php
@@ -67,6 +67,21 @@ return [
     ],
 
     /*
+   |--------------------------------------------------------------------------
+   | Table Names
+   |--------------------------------------------------------------------------
+   |
+   | By default, Verbs prefixes all of its table names with "verb_". However, you
+   | may wish to customize these table names to better fit your application.
+   |
+   */
+    'connections' => [
+        'events' => env('VERBS_EVENTS_CONNECTION'),
+        'snapshots' => env('VERBS_SNAPSHOT_CONNECTION'),
+        'state_events' => env('VERBS_STATE_EVENTS_CONNECTION'),
+    ],
+
+    /*
     |--------------------------------------------------------------------------
     | Table Names
     |--------------------------------------------------------------------------

--- a/database/migrations/2024_04_16_115559_create_verb_events_table.php
+++ b/database/migrations/2024_04_16_115559_create_verb_events_table.php
@@ -9,11 +9,11 @@ return new class extends Migration
     public function up()
     {
         // If they've already migrated under the previous migration name, just skip
-        if (Schema::hasTable($this->tableName())) {
+        if (Schema::connection($this->connectionName())->hasTable($this->tableName())) {
             return;
         }
 
-        Schema::create($this->tableName(), function (Blueprint $table) {
+        Schema::connection($this->connectionName())->create($this->tableName(), function (Blueprint $table) {
             $table->snowflakeId();
 
             $table->string('type')->index();
@@ -26,7 +26,12 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::dropIfExists($this->tableName());
+        Schema::connection($this->connectionName())->dropIfExists($this->tableName());
+    }
+
+    protected function connectionName(): ?string
+    {
+        return config('verbs.connections.events');
     }
 
     protected function tableName(): string

--- a/database/migrations/2024_04_16_115559_create_verb_state_events_table.php
+++ b/database/migrations/2024_04_16_115559_create_verb_state_events_table.php
@@ -10,18 +10,18 @@ return new class extends Migration
     public function up()
     {
         // If they've already migrated under the previous migration name, just skip
-        if (Schema::hasTable($this->tableName())) {
+        if (Schema::connection($this->connectionName())->hasTable($this->tableName())) {
             return;
         }
 
-        Schema::create($this->tableName(), function (Blueprint $table) {
+        Schema::connection($this->connectionName())->create($this->tableName(), function (Blueprint $table) {
             $table->snowflakeId();
 
             $table->snowflake('event_id')->index();
 
             // The 'state_id' column needs to be set up differently depending
             // on if you're using Snowflakes vs. ULIDs/etc.
-            Id::createColumnDefinition($table, 'state_id')->index();
+            Id::createColumnDefinition($table, 'state_id')->connection($this->connectionName())->index();
 
             $table->string('state_type')->index();
 
@@ -31,7 +31,12 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::dropIfExists($this->tableName());
+        Schema::connection($this->connectionName())->dropIfExists($this->tableName());
+    }
+
+    protected function connectionName(): ?string
+    {
+        return config('verbs.connections.state_events');
     }
 
     protected function tableName(): string

--- a/database/migrations/2024_04_16_115559_create_verb_state_events_table.php
+++ b/database/migrations/2024_04_16_115559_create_verb_state_events_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
 
             // The 'state_id' column needs to be set up differently depending
             // on if you're using Snowflakes vs. ULIDs/etc.
-            Id::createColumnDefinition($table, 'state_id')->connection($this->connectionName())->index();
+            Id::createColumnDefinition($table, 'state_id')->index();
 
             $table->string('state_type')->index();
 

--- a/src/Models/VerbEvent.php
+++ b/src/Models/VerbEvent.php
@@ -28,6 +28,11 @@ class VerbEvent extends Model
 
     protected ?Metadata $meta = null;
 
+    public function getConnectionName()
+    {
+        return $this->connection ?? config('verbs.connections.events');
+    }
+
     public function getTable()
     {
         return $this->table ?? config('verbs.tables.events', 'verb_events');

--- a/src/Models/VerbSnapshot.php
+++ b/src/Models/VerbSnapshot.php
@@ -22,6 +22,11 @@ class VerbSnapshot extends Model
 
     protected ?State $state = null;
 
+    public function getConnectionName()
+    {
+        return $this->connection ?? config('verbs.connections.snapshots');
+    }
+
     public function getTable()
     {
         return $this->table ?? config('verbs.tables.snapshots', 'verb_snapshots');

--- a/src/Models/VerbStateEvent.php
+++ b/src/Models/VerbStateEvent.php
@@ -9,6 +9,11 @@ class VerbStateEvent extends Model
 {
     public $guarded = [];
 
+    public function getConnectionName()
+    {
+        return $this->connection ?? config('verbs.connections.state_events');
+    }
+
     public function getTable()
     {
         return $this->table ?? config('verbs.tables.state_events', 'verb_state_events');

--- a/tests/Unit/ConfigurableTableNamesTest.php
+++ b/tests/Unit/ConfigurableTableNamesTest.php
@@ -4,6 +4,16 @@ use Thunk\Verbs\Models\VerbEvent;
 use Thunk\Verbs\Models\VerbSnapshot;
 use Thunk\Verbs\Models\VerbStateEvent;
 
+test('VerbEvent connection name can be configured', function () {
+    $expected_connection_name = 'events';
+
+    config()->set('verbs.connections.events', $expected_connection_name);
+
+    $verb_model = new VerbEvent;
+    $actual_connection_name = $verb_model->getConnectionName();
+    expect($expected_connection_name)->toBe($actual_connection_name);
+});
+
 test('VerbEvent table name can be configured', function () {
     $expected_table_name = 'verb_events';
 
@@ -24,6 +34,16 @@ test('VerbEvent table name can be configured with different table name', functio
     expect($expected_table_name)->toBe($actual_table_name);
 });
 
+test('VerbSnapshot connection name can be configured', function () {
+    $expected_connection_name = 'events';
+
+    config()->set('verbs.connections.snapshots', $expected_connection_name);
+
+    $verb_model = new VerbSnapshot;
+    $actual_connection_name = $verb_model->getConnectionName();
+    expect($expected_connection_name)->toBe($actual_connection_name);
+});
+
 test('VerbSnapshot table name can be configured', function () {
     $expected_table_name = 'verb_snapshots';
 
@@ -42,6 +62,16 @@ test('VerbSnapshot table name can be configured with different table name', func
     $actual_table_name = $verb_model->getTable();
 
     expect($expected_table_name)->toBe($actual_table_name);
+});
+
+test('VerbStateEvent connection name can be configured', function () {
+    $expected_connection_name = 'events';
+
+    config()->set('verbs.connections.state_events', $expected_connection_name);
+
+    $verb_model = new VerbStateEvent;
+    $actual_connection_name = $verb_model->getConnectionName();
+    expect($expected_connection_name)->toBe($actual_connection_name);
 });
 
 test('VerbStateEvent table name can be configured', function () {


### PR DESCRIPTION
You know how you're always wanting to use a separate database connection for your event sourcing but, oh no! There's no way to configure that. Well now there is!

In this exciting PR you'll find:
- Updated configs!
- Updated migrations!
- Updated models!

But that's not all!
This PR also includes passing tests!

Merge now, developers are standing by!


! - I just wanted to add one more exclamation mark.