### PR TITLE
Add naive load many approach to load

### DIFF
--- a/src/Contracts/StoresSnapshots.php
+++ b/src/Contracts/StoresSnapshots.php
@@ -6,10 +6,11 @@ use Glhd\Bits\Bits;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\State;
+use Thunk\Verbs\Support\StateCollection;
 
 interface StoresSnapshots
 {
-    public function load(Bits|UuidInterface|AbstractUid|int|string $id, string $type): ?State;
+    public function load(Bits|UuidInterface|AbstractUid|iterable|int|string $id, string $type): State|StateCollection|null;
 
     public function loadSingleton(string $type): ?State;
 

--- a/src/Lifecycle/SnapshotStore.php
+++ b/src/Lifecycle/SnapshotStore.php
@@ -3,6 +3,8 @@
 namespace Thunk\Verbs\Lifecycle;
 
 use Glhd\Bits\Bits;
+use Illuminate\Database\MultipleRecordsFoundException;
+use Illuminate\Support\Collection;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Contracts\StoresSnapshots;
@@ -11,6 +13,7 @@ use Thunk\Verbs\Facades\Id;
 use Thunk\Verbs\Models\VerbSnapshot;
 use Thunk\Verbs\State;
 use Thunk\Verbs\Support\Serializer;
+use Thunk\Verbs\Support\StateCollection;
 
 class SnapshotStore implements StoresSnapshots
 {
@@ -19,14 +22,11 @@ class SnapshotStore implements StoresSnapshots
         protected Serializer $serializer,
     ) {}
 
-    public function load(Bits|UuidInterface|AbstractUid|int|string $id, string $type): ?State
+    public function load(Bits|UuidInterface|AbstractUid|iterable|int|string $id, string $type): State|StateCollection|null
     {
-        $snapshot = VerbSnapshot::firstWhere([
-            'state_id' => Id::from($id),
-            'type' => $type,
-        ]);
-
-        return $snapshot?->state();
+        return is_iterable($id)
+            ? $this->loadMany(collect($id), $type)
+            : $this->loadOne($id, $type);
     }
 
     public function loadSingleton(string $type): ?State
@@ -53,7 +53,7 @@ class SnapshotStore implements StoresSnapshots
             $upserted = VerbSnapshot::upsert(
                 values: collect($chunk)->map($this->formatForWrite(...))->unique('id')->all(),
                 uniqueBy: ['id'],
-                update: ['data', 'last_event_id', 'updated_at']
+                update: ['data', 'last_event_id', 'updated_at'],
             );
 
             if (! $upserted) {
@@ -69,6 +69,38 @@ class SnapshotStore implements StoresSnapshots
         VerbSnapshot::truncate();
 
         return true;
+    }
+
+    protected function loadOne(Bits|UuidInterface|AbstractUid|int|string $id, string $type): ?State
+    {
+        // This mimics "sole" but returns null if no records are found rather than triggering an exception
+
+        $snapshots = VerbSnapshot::query()
+            ->where('type', '=', $type)
+            ->where('id', $id)
+            ->take(2)
+            ->get();
+
+        $count = $snapshots->count();
+
+        return match ($count) {
+            0 => null,
+            1 => $snapshots->first()->state(),
+            default => throw new MultipleRecordsFoundException($count),
+        };
+    }
+
+    protected function loadMany(Collection $ids, string $type): StateCollection
+    {
+        $ids->ensure([Bits::class, UuidInterface::class, AbstractUid::class, 'int', 'string']);
+
+        $states = VerbSnapshot::query()
+            ->where('type', '=', $type)
+            ->whereIn('id', $ids)
+            ->get()
+            ->map(fn (VerbSnapshot $snapshot) => $snapshot->state());
+
+        return StateCollection::make($states);
     }
 
     protected function formatForWrite(State $state): array

--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -3,7 +3,6 @@
 namespace Thunk\Verbs\Lifecycle;
 
 use Glhd\Bits\Bits;
-use Illuminate\Support\Collection;
 use LogicException;
 use Ramsey\Uuid\UuidInterface;
 use ReflectionClass;
@@ -35,14 +34,17 @@ class StateManager
         return $this->remember($state);
     }
 
-    /** @param  class-string<State>  $type */
-    public function load(Bits|UuidInterface|AbstractUid|int|string|array|Collection $id, string $type): StateCollection|State
+    /**
+     * @template S instanceof State
+     *
+     * @param  class-string<S>  $type
+     * @return S|StateCollection<int,S>
+     */
+    public function load(Bits|UuidInterface|AbstractUid|iterable|int|string $id, string $type): StateCollection|State
     {
-        $ids = StateCollection::wrap($id);
-
-        $states = $ids->map(fn ($id) => $this->loadOne($id, $type));
-
-        return $states->count() === 1 ? $states->first() : $states;
+        return is_iterable($id)
+            ? $this->loadMany($id, $type)
+            : $this->loadOne($id, $type);
     }
 
     /** @param  class-string<State>  $type */
@@ -148,6 +150,34 @@ class StateManager
         $this->reconstitute($state);
 
         return $state;
+    }
+
+    /** @param  class-string<State>  $type */
+    protected function loadMany(iterable $ids, string $type): StateCollection
+    {
+        $ids = collect($ids)->map(Id::from(...));
+
+        $missing = $ids->reject(fn ($id) => $this->states->has($this->key($id, $type)));
+
+        // Load all available snapshots for missing states
+        $this->snapshots->load($missing, $type)->each(function (State $state) {
+            $this->remember($state);
+            $this->reconstitute($state);
+        });
+
+        // Then make any states that don't exist yet
+        $missing
+            ->reject(fn ($id) => $this->states->has($this->key($id, $type)))
+            ->each(function (string|int $id) use ($type) {
+                $state = $this->make($id, $type);
+                $this->remember($state);
+                $this->reconstitute($state);
+            });
+
+        // At this point, all the states should be in our cache, so we can just load everything
+        return StateCollection::make(
+            $ids->map(fn ($id) => $this->states->get($this->key($id, $type)))
+        );
     }
 
     protected function reconstitute(State $state, bool $singleton = false): static

--- a/src/Lifecycle/StateManager.php
+++ b/src/Lifecycle/StateManager.php
@@ -3,7 +3,6 @@
 namespace Thunk\Verbs\Lifecycle;
 
 use Glhd\Bits\Bits;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use LogicException;
 use Ramsey\Uuid\UuidInterface;
@@ -37,7 +36,7 @@ class StateManager
     }
 
     /** @param  class-string<State>  $type */
-    public function load(Bits|UuidInterface|AbstractUid|int|string|array|Collection $id, string $type): StateCollection | State
+    public function load(Bits|UuidInterface|AbstractUid|int|string|array|Collection $id, string $type): StateCollection|State
     {
         $ids = StateCollection::wrap($id);
 

--- a/src/State.php
+++ b/src/State.php
@@ -12,6 +12,7 @@ use Thunk\Verbs\Contracts\StoresEvents;
 use Thunk\Verbs\Exceptions\StateNotFoundException;
 use Thunk\Verbs\Lifecycle\StateManager;
 use Thunk\Verbs\Support\Serializer;
+use Thunk\Verbs\Support\StateCollection;
 
 abstract class State implements UrlRoutable
 {
@@ -64,12 +65,12 @@ abstract class State implements UrlRoutable
         return $result;
     }
 
-    public static function load($from): static
+    public static function load($from): static|StateCollection
     {
         return static::loadByKey(static::normalizeKey($from));
     }
 
-    public static function loadByKey($from): static
+    public static function loadByKey($from): static|StateCollection
     {
         return app(StateManager::class)->load($from, static::class);
     }

--- a/src/Testing/SnapshotStoreFake.php
+++ b/src/Testing/SnapshotStoreFake.php
@@ -13,6 +13,7 @@ use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Contracts\StoresSnapshots;
 use Thunk\Verbs\Facades\Id;
 use Thunk\Verbs\State;
+use Thunk\Verbs\Support\StateCollection;
 
 class SnapshotStoreFake implements StoresSnapshots
 {
@@ -36,8 +37,14 @@ class SnapshotStoreFake implements StoresSnapshots
         return true;
     }
 
-    public function load(UuidInterface|string|int|AbstractUid|Bits $id, string $type): ?State
+    public function load(Bits|UuidInterface|AbstractUid|iterable|int|string $id, string $type): State|StateCollection|null
     {
+        if (is_iterable($id)) {
+            return StateCollection::make(collect($id)
+                ->map(fn ($id) => $this->states[$type][Id::from($id)] ?? null)
+                ->filter());
+        }
+
         return $this->states[$type][Id::from($id)] ?? null;
     }
 

--- a/tests/Unit/LoadManyStatesTest.php
+++ b/tests/Unit/LoadManyStatesTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+use Thunk\Verbs\State;
+
+it('can load many states from an array of ids', function () {
+    $id1 = snowflake_id();
+    $id2 = snowflake_id();
+
+    LoadManyStatesTestEvent::commit(
+        state_id: $id1
+    );
+
+    LoadManyStatesTestEvent::commit(
+        state_id: $id2
+    );
+
+    $state1 = LoadManyStatesTestState::load($id1);
+    $state2 = LoadManyStatesTestState::load($id2);
+
+    $states = LoadManyStatesTestState::load([$id1, $id2]);
+
+    $this->assertEquals($state1, $states->first());
+    $this->assertEquals($state2, $states->last());
+});
+
+it('can load many states from a collection of ids', function () {
+    $id1 = snowflake_id();
+    $id2 = snowflake_id();
+
+    LoadManyStatesTestEvent::commit(
+        state_id: $id1
+    );
+
+    LoadManyStatesTestEvent::commit(
+        state_id: $id2
+    );
+
+    $state1 = LoadManyStatesTestState::load($id1);
+    $state2 = LoadManyStatesTestState::load($id2);
+
+    $states = LoadManyStatesTestState::load(collect([$id1, $id2]));
+
+    $this->assertEquals($state1, $states->first());
+    $this->assertEquals($state2, $states->last());
+});
+
+class LoadManyStatesTestState extends State
+{
+    public bool $acknowledged = false;
+}
+
+class LoadManyStatesTestEvent extends Event
+{
+    #[StateId(LoadManyStatesTestState::class)]
+    public int $state_id;
+
+    #[StateId(LoadManyStatesTestState::class, autofill: false)]
+    public ?int $other_state_id = null;
+
+    public function apply(LoadManyStatesTestState $state, LoadManyStatesTestState $other_state)
+    {
+        $state->acknowledged = true;
+        $other_state->acknowledged = true;
+    }
+}

--- a/tests/Unit/LoadManyStatesTest.php
+++ b/tests/Unit/LoadManyStatesTest.php
@@ -2,7 +2,6 @@
 
 use Thunk\Verbs\Attributes\Autodiscovery\StateId;
 use Thunk\Verbs\Event;
-use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\State;
 
 it('can load many states from an array of ids', function () {


### PR DESCRIPTION
This PR adds support for passing an array or collection of IDs to `State::load()`, to load multiple states. `load`() will return a StateCollection of loaded states.

```php
$states = MyState::load([1, 2, 5, 8]);
```

The caveat here is that this just wraps up the existing load functionality, so it does cause n+1 issues.

This saves people having to do this manually

```php
$states = StateCollection::wrap([1, 2, 5, 8])->map(
    fn($id) => MyState::load($id)
);
```

I looked into creating a load method that can load multiple states with only a couple of queries, but due to the state event queries using the `after_event_id` makes the query a lot more difficult.

So for now I have just opted to keep it simple.