### PR TITLE
Fix snapshot store loading

### DIFF
--- a/src/Lifecycle/SnapshotStore.php
+++ b/src/Lifecycle/SnapshotStore.php
@@ -77,7 +77,7 @@ class SnapshotStore implements StoresSnapshots
 
         $snapshots = VerbSnapshot::query()
             ->where('type', '=', $type)
-            ->where('id', $id)
+            ->where('state_id', $id)
             ->take(2)
             ->get();
 
@@ -96,7 +96,7 @@ class SnapshotStore implements StoresSnapshots
 
         $states = VerbSnapshot::query()
             ->where('type', '=', $type)
-            ->whereIn('id', $ids)
+            ->whereIn('state_id', $ids)
             ->get()
             ->map(fn (VerbSnapshot $snapshot) => $snapshot->state());
 

--- a/tests/Unit/SnapshotStoreTest.php
+++ b/tests/Unit/SnapshotStoreTest.php
@@ -27,25 +27,25 @@ it('can store multiple different states with the same ID', function () {
 
 it('loads snapshots based on the state_id', function () {
     SnapshotStoreTestEvent::commit(
-        state_id: 'abc',
+        state_id: 321,
         name: 'event one',
     );
 
     $store = app(StoresSnapshots::class);
 
-    $state = $store->load('abc', SnapshotStoreTestDifferentState::class);
+    $state = $store->load(321, SnapshotStoreTestDifferentState::class);
 
     expect($state)
-        ->id->toBe('abc')
+        ->id->toBe(321)
         ->name->toBe('event one');
 
-    $states = $store->load(['abc'], SnapshotStoreTestDifferentState::class);
+    $states = $store->load([321], SnapshotStoreTestDifferentState::class);
 
     expect($states)
         ->count()->toBe(1);
 
     expect($states->first())
-        ->id->toBe('abc')
+        ->id->toBe(321)
         ->name->toBe('event one');
 });
 
@@ -68,7 +68,7 @@ class SnapshotStoreTestStateTwo extends State
 class SnapshotStoreTestEvent extends Event
 {
     #[StateId(SnapshotStoreTestDifferentState::class)]
-    public string $state_id;
+    public int $state_id;
 
     public string $name;
 

--- a/tests/Unit/SnapshotStoreTest.php
+++ b/tests/Unit/SnapshotStoreTest.php
@@ -35,13 +35,13 @@ it('loads snapshots based on the state_id', function () {
 
     $store = app(StoresSnapshots::class);
 
-    $state = $store->load($id, SnapshotStoreTestDifferentState::class);
+    $state = $store->load($id, 'SnapshotStoreTestDifferentState');
 
     expect($state)
         ->id->toBe($id->id())
         ->name->toBe('event one');
 
-    $states = $store->load([$id], SnapshotStoreTestDifferentState::class);
+    $states = $store->load([$id], 'SnapshotStoreTestDifferentState');
 
     expect($states)
         ->count()->toBe(1);

--- a/tests/Unit/SnapshotStoreTest.php
+++ b/tests/Unit/SnapshotStoreTest.php
@@ -26,26 +26,28 @@ it('can store multiple different states with the same ID', function () {
 });
 
 it('loads snapshots based on the state_id', function () {
+    $id = snowflake()->make();
+
     SnapshotStoreTestEvent::commit(
-        state_id: 321,
+        state_id: $id,
         name: 'event one',
     );
 
     $store = app(StoresSnapshots::class);
 
-    $state = $store->load(321, SnapshotStoreTestDifferentState::class);
+    $state = $store->load($id, SnapshotStoreTestDifferentState::class);
 
     expect($state)
-        ->id->toBe(321)
+        ->id->toBe($id)
         ->name->toBe('event one');
 
-    $states = $store->load([321], SnapshotStoreTestDifferentState::class);
+    $states = $store->load([$id], SnapshotStoreTestDifferentState::class);
 
     expect($states)
         ->count()->toBe(1);
 
     expect($states->first())
-        ->id->toBe(321)
+        ->id->toBe($id)
         ->name->toBe('event one');
 });
 

--- a/tests/Unit/SnapshotStoreTest.php
+++ b/tests/Unit/SnapshotStoreTest.php
@@ -38,6 +38,15 @@ it('loads snapshots based on the state_id', function () {
     expect($state)
         ->id->toBe('abc')
         ->name->toBe('event one');
+
+    $states = $store->load(['abc'], SnapshotStoreTestDifferentState::class);
+
+    expect($states)
+        ->count()->toBe(1);
+
+    expect($states->first())
+        ->id->toBe('abc')
+        ->name->toBe('event one');
 });
 
 class SnapshotStoreTestStateOne extends State

--- a/tests/Unit/SnapshotStoreTest.php
+++ b/tests/Unit/SnapshotStoreTest.php
@@ -38,7 +38,7 @@ it('loads snapshots based on the state_id', function () {
     $state = $store->load($id, SnapshotStoreTestDifferentState::class);
 
     expect($state)
-        ->id->toBe($id)
+        ->id->toBe($id->id())
         ->name->toBe('event one');
 
     $states = $store->load([$id], SnapshotStoreTestDifferentState::class);
@@ -47,7 +47,7 @@ it('loads snapshots based on the state_id', function () {
         ->count()->toBe(1);
 
     expect($states->first())
-        ->id->toBe($id)
+        ->id->toBe($id->id())
         ->name->toBe('event one');
 });
 
@@ -70,7 +70,7 @@ class SnapshotStoreTestStateTwo extends State
 class SnapshotStoreTestEvent extends Event
 {
     #[StateId(SnapshotStoreTestDifferentState::class)]
-    public int $state_id;
+    public Bits $state_id;
 
     public string $name;
 

--- a/tests/Unit/SnapshotStoreTest.php
+++ b/tests/Unit/SnapshotStoreTest.php
@@ -3,7 +3,9 @@
 use Glhd\Bits\Bits;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Uid\AbstractUid;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
 use Thunk\Verbs\Contracts\StoresSnapshots;
+use Thunk\Verbs\Event;
 use Thunk\Verbs\Models\VerbSnapshot;
 use Thunk\Verbs\State;
 
@@ -23,6 +25,21 @@ it('can store multiple different states with the same ID', function () {
         ->and($snapshot1)->id->not()->toBe($snapshot2->id);
 });
 
+it('loads snapshots based on the state_id', function () {
+    SnapshotStoreTestEvent::commit(
+        state_id: 'abc',
+        name: 'event one',
+    );
+
+    $store = app(StoresSnapshots::class);
+
+    $state = $store->load('abc', SnapshotStoreTestDifferentState::class);
+
+    expect($state)
+        ->id->toBe('abc')
+        ->name->toBe('event one');
+});
+
 class SnapshotStoreTestStateOne extends State
 {
     public function __construct(
@@ -37,4 +54,24 @@ class SnapshotStoreTestStateTwo extends State
         public Bits|UuidInterface|AbstractUid|int|string|null $id,
         public string $name,
     ) {}
+}
+
+class SnapshotStoreTestEvent extends Event
+{
+    #[StateId(SnapshotStoreTestDifferentState::class)]
+    public string $state_id;
+
+    public string $name;
+
+    public function apply(SnapshotStoreTestDifferentState $state)
+    {
+        $state->name = $this->name;
+    }
+}
+
+class SnapshotStoreTestDifferentState extends State
+{
+    public Bits|UuidInterface|AbstractUid|int|string|null $id;
+
+    public string $name;
 }

--- a/tests/Unit/SnapshotStoreTest.php
+++ b/tests/Unit/SnapshotStoreTest.php
@@ -35,13 +35,13 @@ it('loads snapshots based on the state_id', function () {
 
     $store = app(StoresSnapshots::class);
 
-    $state = $store->load($id, 'SnapshotStoreTestDifferentState');
+    $state = $store->load($id, SnapshotStoreTestDifferentState::class);
 
     expect($state)
         ->id->toBe($id->id())
         ->name->toBe('event one');
 
-    $states = $store->load([$id], 'SnapshotStoreTestDifferentState');
+    $states = $store->load([$id], SnapshotStoreTestDifferentState::class);
 
     expect($states)
         ->count()->toBe(1);


### PR DESCRIPTION
PR #171 added the option to loadMany states based on an array of IDs, but this commit 68e88ac95719bd337c6fcb693ffc66f73ca081ab broke in how the snapshots were loaded from the database as the where clause got changed from `state_id` to `id`.

So this PR changes it back to `state_id` and adds a test that ensures both loadOne and loadMany function correctly.

Edit: Tests are failing only on Laravel 10 lowest, so maybe there is a bug with the collection `->ensure()` method in an older Laravel 10 version.