### PR TITLE
Fix event state property loading

### DIFF
--- a/src/Support/EventStateRegistry.php
+++ b/src/Support/EventStateRegistry.php
@@ -110,7 +110,7 @@ class EventStateRegistry
     /** @return Collection<int, State> */
     protected function getProperties(Event $target): Collection
     {
-        return $this->discovered_properties[$target::class] ??= $this->findAllProperties($target);
+        return $this->discovered_properties[$target::class][$target->id] ??= $this->findAllProperties($target);
     }
 
     /** @return Collection<int, State> */

--- a/tests/Unit/UseStatesDirectlyInEventsTest.php
+++ b/tests/Unit/UseStatesDirectlyInEventsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\State;
 use Thunk\Verbs\Support\StateCollection;
 
@@ -66,6 +67,28 @@ it('supports state collections', function () {
 
     $this->assertTrue($user_request1->processed);
     $this->assertTrue($user_request2->processed);
+});
+
+it('loads the correct state when multiple are used', function () {
+    $user_request1 = UserRequestState::new();
+
+    $event1 = UserRequestAcknowledged::fire(
+        user_request: $user_request1
+    );
+
+    $this->assertTrue($user_request1->acknowledged);
+
+    $this->assertEquals($event1->id, $user_request1->last_event_id);
+
+    $user_request2 = UserRequestState::new();
+
+    $event2 = UserRequestAcknowledged::fire(
+        user_request: $user_request2
+    );
+
+    $this->assertTrue($user_request2->acknowledged);
+
+    $this->assertEquals($event2->id, $user_request2->last_event_id);
 });
 
 class UserRequestState extends State

--- a/tests/Unit/UseStatesDirectlyInEventsTest.php
+++ b/tests/Unit/UseStatesDirectlyInEventsTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Thunk\Verbs\Event;
-use Thunk\Verbs\Facades\Verbs;
 use Thunk\Verbs\State;
 use Thunk\Verbs\Support\StateCollection;
 


### PR DESCRIPTION
PR #169 added support for using states directly as properties on events.

But there is an issue when multiple events, that are applied to different states, are fired one after another where all subsequent events were being applied to the first state instead of the correct state.

This is because in the `EventStateRegistry` we are memoizing the properties loaded from the event, similar to how attributes are being loaded and memoized.

But the issue is that attributes don't have state, so can be memoized based on the event class. This doesn't work for properties as they do actually have state, as such the load state was being returned from the memoized properties.

So this PR fixes it by ensuring the memoization for properties is scoped to the event ID as well as the event class and adds tests.