### PR TITLE
Bump Laravel Prompts version for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "glhd/bits": ">=0.3.0",
         "illuminate/contracts": "^10.34|^11.0",
         "internachi/modular": "^2.0",
-        "laravel/prompts": "^0.1.15",
+        "laravel/prompts": "^0.2.1",
         "spatie/laravel-package-tools": "^1.14.0",
         "symfony/property-access": "^6.2|^7.0",
         "symfony/serializer": "^6.3|^7.0"


### PR DESCRIPTION
Hey,

just wanted to open this pull request as I'm getting a composer dependency issue when trying to install Verbs into a brand new Laravel 11 installation.

Stack: Herd
PHP: v8.3
Laravel: v11

```bash
composer require hirethunk/verbs
./composer.json has been updated
Running composer update hirethunk/verbs
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - hirethunk/verbs[0.0.1, ..., v0.1.1] require illuminate/contracts ^10.0 -> found illuminate/contracts[v10.0.0, ..., v10.48.22] but these were not loaded, likely because it conflicts with another require.
    - hirethunk/verbs[v0.1.2, ..., v0.6.2] require laravel/prompts ^0.1.15 -> found laravel/prompts[v0.1.15, ..., v0.1.25] but it conflicts with your root composer.json require (^0.2.1).
    - Root composer.json requires hirethunk/verbs * -> satisfiable by hirethunk/verbs[0.0.1, ..., v0.6.2].

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
You can also try re-running composer require with an explicit version constraint, e.g. "composer require hirethunk/verbs:*" to figure out if any version is installable, or "composer require hirethunk/verbs:^2.1" if you know which you need.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
``` 
When running the same command with the `-W`flag, the only downgrade that happened was on the version of `laravel/prompts`:

```bash
Downgrading laravel/prompts (v0.2.1 => v0.1.25)
````
Thanks for considering this.