### PR TITLE
Add support for event state properties being nullable

### DIFF
--- a/src/Support/EventStateRegistry.php
+++ b/src/Support/EventStateRegistry.php
@@ -119,11 +119,16 @@ class EventStateRegistry
         $reflect = new ReflectionClass($target);
 
         return collect($reflect->getProperties(ReflectionProperty::IS_PUBLIC))
-            ->filter(function (ReflectionProperty $property) {
-                $propertyType = $property->getType()?->getName();
+            ->filter(function (ReflectionProperty $property) use ($target) {
+                $propertyType = $property->getType();
+                $propertyTypeName = $propertyType?->getName();
 
-                return $propertyType
-                    && (is_subclass_of($propertyType, State::class) || $propertyType === State::class || $propertyType === StateCollection::class);
+                if ($propertyType->allowsNull() && $property->getValue($target) === null) {
+                    return false;
+                }
+
+                return $propertyTypeName
+                    && (is_subclass_of($propertyTypeName, State::class) || $propertyTypeName === State::class || $propertyTypeName === StateCollection::class);
             })
             ->map(fn (ReflectionProperty $property) => $property->getValue($target))
             ->flatten();

--- a/tests/Unit/UseStatesDirectlyInEventsTest.php
+++ b/tests/Unit/UseStatesDirectlyInEventsTest.php
@@ -34,6 +34,17 @@ it('supports singleton states', function () {
     $this->assertTrue($user_request->acknowledged);
 });
 
+it('supports nullable state properties', function () {
+    $user_request1 = UserRequestState::new();
+
+    UserRequestsWithNullable::commit(
+        user_request1: $user_request1,
+        user_request2: null,
+    );
+
+    $this->assertTrue($user_request1->nullable);
+});
+
 it('supports using a nested state directly in events', function () {
     $parent = ParentState::new();
     $child = ChildState::new();
@@ -95,6 +106,8 @@ class UserRequestState extends State
     public bool $acknowledged = false;
 
     public bool $processed = false;
+
+    public bool $nullable = false;
 }
 
 class UserRequestAcknowledged extends Event
@@ -120,6 +133,19 @@ class UserRequestsProcessed extends Event
         $this->user_requests->each(
             fn (UserRequestState $user_request) => $user_request->processed = true
         );
+    }
+}
+
+class UserRequestsWithNullable extends Event
+{
+    public function __construct(
+        public UserRequestState $user_request1,
+        public ?UserRequestState $user_request2
+    ) {}
+
+    public function apply()
+    {
+        $this->user_request1->nullable = true;
     }
 }
 


### PR DESCRIPTION
As an extension of PR #169 and PR #174, this PR adds support for allowing event state properties to be nullable.

At the moment, if we try to pass `null` into an event property that is typehinted to state like this:

```php
class UserRequestsWithNullable extends Event
{
    public function __construct(
        public UserRequestState $user_request1,
        public ?UserRequestState $user_request2
    ) {}
}

$user_request1 = UserRequestState::new();

UserRequestsWithNullable::commit(
    user_request1: $user_request1,
    user_request2: null,
);
```

It throws the following error:

<img width="1451" alt="image" src="https://github.com/user-attachments/assets/12486676-7b36-4b77-8bb9-11524fa81c94">

So this PR fixes it by ensuring that any state properties, that allow `null` and are set to `null`, get filtered out of the list of state properties for an event.