### PR TITLE
Ensure states can be restored when using uuids

### DIFF
--- a/src/Support/Normalization/StateNormalizer.php
+++ b/src/Support/Normalization/StateNormalizer.php
@@ -13,7 +13,7 @@ class StateNormalizer implements DenormalizerInterface, NormalizerInterface
 {
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return is_a($type, State::class, true) && (is_numeric($data) || is_a($data, State::class, true));
+        return is_a($type, State::class, true) && (is_numeric($data) || is_string($data) || is_a($data, State::class, true));
     }
 
     /** @param  class-string<State>  $type */
@@ -23,7 +23,7 @@ class StateNormalizer implements DenormalizerInterface, NormalizerInterface
             return $data;
         }
 
-        return app(StateManager::class)->load((int) $data, $type);
+        return app(StateManager::class)->load($data, $type);
     }
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool

--- a/tests/Unit/SupportUuidsTest.php
+++ b/tests/Unit/SupportUuidsTest.php
@@ -1,12 +1,29 @@
 <?php
 
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Str;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Lifecycle\StateManager;
 use Thunk\Verbs\State;
+use Thunk\Verbs\Support\IdManager;
+
+use function Pest\Laravel\artisan;
 
 beforeEach(function () {
+    // This is necessary because our Orchestra setup migrates the database
+    // before our tests run, so we need to re-run our migrations
     config()->set('verbs.id_type', 'uuid');
+    app()->instance(IdManager::class, new IdManager('uuid'));
+    Facade::clearResolvedInstance(IdManager::class);
+    artisan('migrate:fresh');
+});
+
+afterAll(function () {
+    // This just resets the migrations back to how the were before this test suite
+    config()->set('verbs.id_type', 'snowflake');
+    app()->instance(IdManager::class, new IdManager('snowflake'));
+    Facade::clearResolvedInstance(IdManager::class);
+    artisan('migrate:fresh');
 });
 
 it('supports using uuids as state ids', function () {

--- a/tests/Unit/SupportUuidsTest.php
+++ b/tests/Unit/SupportUuidsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Support\Str;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Lifecycle\StateManager;
+use Thunk\Verbs\State;
+
+beforeEach(function () {
+    config()->set('verbs.id_type', 'uuid');
+});
+
+it('supports using uuids as state ids', function () {
+    $uuid = (string) Str::orderedUuid();
+
+    $state = UuidState::load($uuid);
+
+    UuidEvent::commit(
+        state: $state,
+    );
+
+    expect($state)
+        ->id->toBe($uuid)
+        ->event_was_applied->toBeTrue();
+});
+
+it('loads states correctly using uuids when the snapshots table has been removed', function () {
+    $uuid = (string) Str::orderedUuid();
+
+    $state = UuidState::load($uuid);
+
+    UuidEvent::commit(
+        state: $state,
+    );
+
+    app(StateManager::class)->reset(include_storage: true);
+
+    $state = UuidState::load($uuid);
+
+    expect($state)
+        ->id->toBe($uuid)
+        ->event_was_applied->toBeTrue();
+});
+
+class UuidState extends State
+{
+    public bool $event_was_applied = false;
+}
+
+class UuidEvent extends Event
+{
+    public UuidState $state;
+
+    public function apply()
+    {
+        $this->state->event_was_applied = true;
+    }
+}


### PR DESCRIPTION
Currently if you use UUIDs instead of Snowflakes, the `StateNormalizer` won't restore the state correctly due to the checks limiting it to integers.

This PR updates the `StateNormalizer` to support strings as well and adds some tests for UUID support.