### PR TITLE
Docs: Fix class declaration syntax errors in the state documentation

### DIFF
--- a/docs/states.md
+++ b/docs/states.md
@@ -56,7 +56,7 @@ to track:
 
 ```php
 // CountIncremented.php
-class CountIncremented class extends Event
+class CountIncremented extends Event
 {
     #[StateId(CountState::class)]
     public int $example_id;
@@ -251,7 +251,7 @@ which frees up your models to better serve your frontfacing UI needs. Once you'v
 your state instance's id to correspond directly to a model instance.
 
 ```php
-class FooCreated class
+class FooCreated
 {
     #[StateId(FooState::class)]
     public int $foo_id;


### PR DESCRIPTION
Dear Reviewer! 

This PR fixes syntax errors in the documentation examples where class declarations were incorrect. 

- Corrected `class CountIncremented class extends Event` to `class CountIncremented extends Event` in the [applying event data to your state](https://verbs.thunk.dev/docs/reference/states#content-applying-event-data-to-your-state)
- Corrected `class FooCreated class` to [`class FooCreated` in the [what should be a state](https://verbs.thunk.dev/docs/reference/states#content-what-should-be-a-state)

These changes ensure the code examples reflect valid PHP syntax and help avoid confusion for users following the documentation.
