### PR TITLE
Add support for prompts v0.2 and v0.3 to make it compatible with the latest version of Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "glhd/bits": ">=0.3.0",
         "illuminate/contracts": "^10.34|^11.0",
         "internachi/modular": "^2.0",
-        "laravel/prompts": "^0.1.15",
+        "laravel/prompts": "^0.1.15|^0.2|^0.3",
         "spatie/laravel-package-tools": "^1.14.0",
         "symfony/property-access": "^6.2|^7.0",
         "symfony/serializer": "^6.3|^7.0"


### PR DESCRIPTION
laravel/prompts has had new versions tagged (v0.2 and v0.3). But due to semver, they are treaded like major version bumps, so Verbs can't be installed with the latest version of laravel/framework as it requires prompts v0.3

This PR updates Verb's required prompts versions to include both of them like we did in Livewire https://github.com/livewire/livewire/pull/8887#discussion_r1782057425