### PR TITLE
Add Snowflake casts to Eloquent Model example in docs

### DIFF
--- a/docs/ids.md
+++ b/docs/ids.md
@@ -17,9 +17,17 @@ A helper method you can use to generate a snowflake right out of the box: `snowf
 For models that you're going to manage via events, pull in the `HasSnowflakes` trait:
 
 ```php
+use Glhd\Bits\Database\HasSnowflakes;
+use Glhd\Bits\Snowflake;
+
 class JobApplication extends Model
 {
     use HasSnowflakes; // Add this to your model
+
+    // Any attribute can be cast to a `Snowflake` (or `Sonyflake`)
+    protected $casts = [
+        'id' => Snowflake::class,
+    ];
 }
 ```
 


### PR DESCRIPTION
When using Snowflakes on models (especially with Livewire), it's good practice to add the snowflake casts to the model as per the bits documentation https://github.com/glhd/bits?tab=readme-ov-file#usage-with-eloquent-models

This PR updates the Snowflake Eloquent Model example to include the Snowflake casts.

```php
use Glhd\Bits\Database\HasSnowflakes;
use Glhd\Bits\Snowflake;

class JobApplication extends Model
{
    use HasSnowflakes; // Add this to your model

    // Any attribute can be cast to a `Snowflake` (or `Sonyflake`)
    protected $casts = [
        'id' => Snowflake::class,
    ];
}
```