### PR TITLE
Simple migrations

### DIFF
--- a/config/verbs.php
+++ b/config/verbs.php
@@ -6,6 +6,7 @@ use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Thunk\Verbs\Support\Normalization\BitsNormalizer;
 use Thunk\Verbs\Support\Normalization\CarbonNormalizer;
 use Thunk\Verbs\Support\Normalization\CollectionNormalizer;
+use Thunk\Verbs\Support\Normalization\EventMigrationNormalizer;
 use Thunk\Verbs\Support\Normalization\ModelNormalizer;
 use Thunk\Verbs\Support\Normalization\SelfSerializingNormalizer;
 use Thunk\Verbs\Support\Normalization\StateNormalizer;
@@ -40,6 +41,7 @@ return [
     |
     */
     'normalizers' => [
+        EventMigrationNormalizer::class,
         SelfSerializingNormalizer::class,
         CollectionNormalizer::class,
         ModelNormalizer::class,

--- a/src/Support/Normalization/EventMigrationNormalizer.php
+++ b/src/Support/Normalization/EventMigrationNormalizer.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Thunk\Verbs\Support\Normalization;
+
+use InvalidArgumentException;
+use ReflectionClass;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerAwareInterface;
+use Thunk\Verbs\Event;
+
+class EventMigrationNormalizer implements DenormalizerInterface, NormalizerInterface, SerializerAwareInterface
+{
+    use AcceptsNormalizerAndDenormalizer;
+
+    public function normalize($object, ?string $format = null, array $context = []): array
+    {
+        if (!$object instanceof Event) {
+            throw new InvalidArgumentException(class_basename($this) . ' can only normalize Events');
+        }
+
+        $context['migrated'] = true;
+
+        return $this->serializer->normalize($object, $format, $context);
+    }
+
+    public function supportsNormalization($data, ?string $format = null, array $context = []): bool
+    {
+        if (!$data instanceof Event) {
+            return false;
+        }
+
+        $alreadyMigrated = $context['migrated'] ?? false;
+
+        return !$alreadyMigrated;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            Event::class => false,
+        ];
+    }
+
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        if (is_string($data)) {
+            $data = json_decode($data, true);
+        }
+
+        if (is_a($data, $type)) {
+            return $data;
+        }
+
+        $reflect = new ReflectionClass($type);
+
+        /** @var Event $instance */
+        $instance = $reflect->newInstanceWithoutConstructor();
+
+        if (method_exists($instance, 'migrate')) {
+            $migrations = $instance::migrate();
+            $data = self::migrate($migrations, $data);
+        }
+
+        $context['migrated'] = true;
+
+        return $this->serializer->denormalize($data, $type, $format, $context);
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        $hasMigrated = $context['migrated'] ?? false;
+
+        return !$hasMigrated && is_a($type, Event::class, true);
+    }
+
+    private static function migrate(array $migrations, array $data): array
+    {
+        $collection = collect($data);
+
+        foreach ($migrations as $migration) {
+            if (is_callable($migration)) {
+                $collection = $migration($collection);
+            }
+        }
+
+        return $collection->all();
+    }
+}

--- a/src/Support/Normalization/EventMigrationNormalizer.php
+++ b/src/Support/Normalization/EventMigrationNormalizer.php
@@ -15,8 +15,8 @@ class EventMigrationNormalizer implements DenormalizerInterface, NormalizerInter
 
     public function normalize($object, ?string $format = null, array $context = []): array
     {
-        if (!$object instanceof Event) {
-            throw new InvalidArgumentException(class_basename($this) . ' can only normalize Events');
+        if (! $object instanceof Event) {
+            throw new InvalidArgumentException(class_basename($this).' can only normalize Events');
         }
 
         $context['migrated'] = true;
@@ -26,13 +26,13 @@ class EventMigrationNormalizer implements DenormalizerInterface, NormalizerInter
 
     public function supportsNormalization($data, ?string $format = null, array $context = []): bool
     {
-        if (!$data instanceof Event) {
+        if (! $data instanceof Event) {
             return false;
         }
 
         $alreadyMigrated = $context['migrated'] ?? false;
 
-        return !$alreadyMigrated;
+        return ! $alreadyMigrated;
     }
 
     public function getSupportedTypes(?string $format): array
@@ -71,7 +71,7 @@ class EventMigrationNormalizer implements DenormalizerInterface, NormalizerInter
     {
         $hasMigrated = $context['migrated'] ?? false;
 
-        return !$hasMigrated && is_a($type, Event::class, true);
+        return ! $hasMigrated && is_a($type, Event::class, true);
     }
 
     private static function migrate(array $migrations, array $data): array

--- a/tests/Feature/SerializationTest.php
+++ b/tests/Feature/SerializationTest.php
@@ -211,7 +211,7 @@ class EventWithMigrations extends Event
     public static function migrate(): array
     {
         return [
-            fn(Collection $v0) => $v0->put('migrated', true),
+            fn (Collection $v0) => $v0->put('migrated', true),
         ];
     }
 }

--- a/tests/Feature/SerializationTest.php
+++ b/tests/Feature/SerializationTest.php
@@ -3,6 +3,7 @@
 use Carbon\CarbonInterface;
 use Glhd\Bits\Bits;
 use Glhd\Bits\Snowflake;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
@@ -156,6 +157,13 @@ it('does not include the state ID or last_event_id in its payload', function () 
     expect($result)->toBe('{"__verbs_initialized":false,"name":"Demo"}');
 });
 
+it('migrates events when deserializing', function () {
+    $event = app(Serializer::class)
+        ->deserialize(EventWithMigrations::class, []);
+
+    expect($event->migrated)->toBe(true);
+});
+
 class EventWithConstructorPromotion extends Event
 {
     public function __construct(
@@ -193,5 +201,17 @@ class EventWithConstructor extends Event
     public function __construct()
     {
         $this->constructed = true;
+    }
+}
+
+class EventWithMigrations extends Event
+{
+    public bool $migrated;
+
+    public static function migrate(): array
+    {
+        return [
+            fn(Collection $v0) => $v0->put('migrated', true),
+        ];
     }
 }


### PR DESCRIPTION
I've added a very basic static migrations method to events. It gets called every time an event gets deserialized (meaning you could run a replay to migrate all data before removing the method).

I simple migration would look like this:
```php
public static function migrate(): array
{
    return [
        fn(Collection $v0) => $v0->put('migrated', true),
    ];
}
```

It will require existing users to add the `MigrationNormalizer::class` to their config if they've published it.
