### PR TITLE
Add Legacy Event handler

### DIFF
--- a/src/Exceptions/UnableToReadEventException.php
+++ b/src/Exceptions/UnableToReadEventException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Thunk\Verbs\Exceptions;
+
+class UnableToReadEventException extends \RuntimeException {}

--- a/src/Facades/Verbs.php
+++ b/src/Facades/Verbs.php
@@ -23,6 +23,7 @@ use Thunk\Verbs\Testing\EventStoreFake;
  * @method static EventStoreFake assertNothingCommitted()
  * @method static CarbonInterface realNow()
  * @method static void skipPhases(Phase ...$phases)
+ * @method static void mapLegacyEvents(array $map)
  */
 class Verbs extends Facade
 {

--- a/src/Lifecycle/BrokerConvenienceMethods.php
+++ b/src/Lifecycle/BrokerConvenienceMethods.php
@@ -78,4 +78,14 @@ trait BrokerConvenienceMethods
     {
         return app(Wormhole::class)->realNow();
     }
+
+    /**
+     * Takes a map of new event classes to legacy event classes
+     *
+     * @param  array<string, array<string, string>>|array<string, string>  $map
+     */
+    public function mapLegacyEvents(array $map): void
+    {
+        app(EventStore::class)->mapLegacyEvents($map);
+    }
 }

--- a/src/Lifecycle/EventStore.php
+++ b/src/Lifecycle/EventStore.php
@@ -21,6 +21,9 @@ use Thunk\Verbs\Support\Serializer;
 
 class EventStore implements StoresEvents
 {
+
+    private array $event_class_map = [];
+
     public function __construct(
         protected MetadataManager $metadata,
     ) {}
@@ -147,5 +150,26 @@ class EventStore implements StoresEvents
                 'updated_at' => now(),
             ]))
             ->all();
+    }
+
+    /**
+     * @param  array<string, array<string, string>>|array<string, string>  $map
+     */
+    public function mapLegacyEvents(array $map): void
+    {
+        foreach ($map as $new_event => $legacy_events) {
+            if (! is_array($legacy_events)) {
+                $legacy_events = [$legacy_events];
+            }
+
+            foreach ($legacy_events as $legacy_event) {
+                $this->event_class_map[$legacy_event] = $new_event;
+            }
+        }
+    }
+
+    public function resolveType(string $type): string
+    {
+        return $this->event_class_map[$type] ?? $type;
     }
 }

--- a/src/Lifecycle/EventStore.php
+++ b/src/Lifecycle/EventStore.php
@@ -21,7 +21,6 @@ use Thunk\Verbs\Support\Serializer;
 
 class EventStore implements StoresEvents
 {
-
     private array $event_class_map = [];
 
     public function __construct(

--- a/tests/Feature/LegacyEventMapTest.php
+++ b/tests/Feature/LegacyEventMapTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+
+it('can map legacy events to new events as an array', function () {
+    Verbs::mapLegacyEvents([
+        NewEvent::class => LegacyEvent::class,
+    ]);
+
+    LegacyEvent::fire(name: 'test');
+
+    Verbs::commit();
+
+    $events = app(\Thunk\Verbs\Lifecycle\EventStore::class)->read();
+
+    $this->assertInstanceOf(NewEvent::class, $events->first());
+});
+
+it('can map legacy events to new events as a nested array', function () {
+    Verbs::mapLegacyEvents([
+        NewEvent::class => [LegacyEvent::class],
+    ]);
+
+    LegacyEvent::fire(name: 'test');
+
+    Verbs::commit();
+
+    $events = app(\Thunk\Verbs\Lifecycle\EventStore::class)->read();
+
+    $this->assertInstanceOf(NewEvent::class, $events->first());
+});
+
+it('throws a helpful exception when an event is not found in the map', function () {
+    NewEvent::fire(name: 'test');
+
+    Verbs::commit();
+
+    $event = \Thunk\Verbs\Models\VerbEvent::first();
+    $event->type = 'non-existent-event';
+    $event->save();
+
+    $this->expectException(\Thunk\Verbs\Exceptions\UnableToReadEventException::class);
+
+    $events = app(\Thunk\Verbs\Lifecycle\EventStore::class)->read();
+});
+
+class LegacyEvent extends Event
+{
+    public function __construct(
+        public string $name,
+    ) {}
+}
+
+class NewEvent extends Event
+{
+    public function __construct(
+        public string $name,
+    ) {}
+}


### PR DESCRIPTION
This PR introduces a new feature that allows mapping of legacy event types to new event classes. This functionality is crucial for maintaining backwards compatibility when refactoring event classes in long-lived applications.

## Usage

You can now map legacy event types to new event classes using the ```Verbs``` facade:

```php
Verbs::mapLegacyEvents([
    NewEvent::class => ['OldEvent', 'VeryOldEvent'],
]);
```

## Why This Is Important

When refactoring event classes in a system that stores events in a database, you may encounter issues with deserializing old events. For example:

```php
class UserRegistered extends Event
{
    public function __construct(public string $username) {}
}

// After refactoring
class UserSignedUp extends Event
{
    public function __construct(public string $username) {}
}
```

Without this mapping feature, trying to replay old ```UserRegistered``` events would fail because the class no longer exists.

With the new mapping feature, you can easily handle such refactoring:

```php
Verbs::mapLegacyEvents([
    UserSignedUp::class => 'UserRegistered',
]);
```

This ensures that old ```UserRegistered``` events in the database are correctly deserialized as ```UserSignedUp``` events.

