### PR TITLE
WIP: Deferred writes during replays

### DIFF
--- a/src/Attributes/Hooks/Latest.php
+++ b/src/Attributes/Hooks/Latest.php
@@ -4,18 +4,15 @@ namespace Thunk\Verbs\Attributes\Hooks;
 
 use Attribute;
 use Thunk\Verbs\Lifecycle\Hook;
-use Thunk\Verbs\Lifecycle\Phase;
 use Thunk\Verbs\Support\DeferredWriteData;
 
 #[Attribute(Attribute::TARGET_METHOD)]
 class Latest implements HookAttribute
 {
     public function __construct(
-        public string|null $unique_id = null,
-       public  ?string $type = null,
-    )
-    {
-    }
+        public ?string $unique_id = null,
+        public ?string $type = null,
+    ) {}
 
     public function applyToHook(Hook $hook): void
     {

--- a/src/Attributes/Hooks/Latest.php
+++ b/src/Attributes/Hooks/Latest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Thunk\Verbs\Attributes\Hooks;
+
+use Attribute;
+use Thunk\Verbs\Lifecycle\Hook;
+use Thunk\Verbs\Lifecycle\Phase;
+use Thunk\Verbs\Support\DeferredWriteData;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Latest implements HookAttribute
+{
+    public function __construct(
+        public string|null $unique_id = null,
+       public  ?string $type = null,
+    )
+    {
+    }
+
+    public function applyToHook(Hook $hook): void
+    {
+        $hook->deferred = new DeferredWriteData($this->type, $this->unique_id);
+    }
+}

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -105,6 +105,7 @@ class Broker implements BrokersEvents
                     }
                 });
         } finally {
+            app(DeferredWriteQueue::class)->flush();
             $this->states->writeSnapshots();
             $this->states->prune();
             $this->states->setReplaying(false);

--- a/src/Lifecycle/DeferredWriteQueue.php
+++ b/src/Lifecycle/DeferredWriteQueue.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Thunk\Verbs\Lifecycle;
+
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Support\DeferredWriteData;
+
+class DeferredWriteQueue
+{
+    private array $callbacks = [];
+    public function add(Event $event, callable $callback, DeferredWriteData $deferred): void
+    {
+        $class = $deferred->class_name ?? get_class($event);
+        $uniqueBy = $deferred->unique_by;
+        $uniqueByKey = (string)$event->$uniqueBy ?? 'Default';
+
+        $this->callbacks[$class][$uniqueByKey] = $callback;
+    }
+
+    public function flush(): void
+    {
+        foreach ($this->callbacks as $callbacks) {
+            foreach ($callbacks as $callback) {
+                $callback();
+            }
+        }
+    }
+}

--- a/src/Lifecycle/DeferredWriteQueue.php
+++ b/src/Lifecycle/DeferredWriteQueue.php
@@ -9,11 +9,12 @@ use Thunk\Verbs\Support\Wormhole;
 class DeferredWriteQueue
 {
     private array $callbacks = [];
+
     public function add(Event $event, callable $callback, DeferredWriteData $deferred): void
     {
         $class = $deferred->class_name ?? get_class($event);
         $uniqueBy = $deferred->unique_by;
-        $uniqueByKey = (string)$event->$uniqueBy ?? 'Default';
+        $uniqueByKey = (string) $event->$uniqueBy ?? 'Default';
 
         $this->callbacks[$class][$uniqueByKey] = [$event, $callback];
     }

--- a/src/Lifecycle/DeferredWriteQueue.php
+++ b/src/Lifecycle/DeferredWriteQueue.php
@@ -4,6 +4,7 @@ namespace Thunk\Verbs\Lifecycle;
 
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Support\DeferredWriteData;
+use Thunk\Verbs\Support\Wormhole;
 
 class DeferredWriteQueue
 {
@@ -14,14 +15,14 @@ class DeferredWriteQueue
         $uniqueBy = $deferred->unique_by;
         $uniqueByKey = (string)$event->$uniqueBy ?? 'Default';
 
-        $this->callbacks[$class][$uniqueByKey] = $callback;
+        $this->callbacks[$class][$uniqueByKey] = [$event, $callback];
     }
 
     public function flush(): void
     {
         foreach ($this->callbacks as $callbacks) {
             foreach ($callbacks as $callback) {
-                $callback();
+                app(Wormhole::class)->warp($callback[0], $callback[1]);
             }
         }
     }

--- a/src/Lifecycle/DeferredWriteQueue.php
+++ b/src/Lifecycle/DeferredWriteQueue.php
@@ -26,5 +26,6 @@ class DeferredWriteQueue
                 app(Wormhole::class)->warp($callback[0], $callback[1]);
             }
         }
+        $this->callbacks = [];
     }
 }

--- a/src/Lifecycle/Hook.php
+++ b/src/Lifecycle/Hook.php
@@ -8,8 +8,6 @@ use ReflectionMethod;
 use RuntimeException;
 use SplObjectStorage;
 use Thunk\Verbs\Event;
-use Thunk\Verbs\Metadata;
-use Thunk\Verbs\State;
 use Thunk\Verbs\Support\DeferredWriteData;
 use Thunk\Verbs\Support\DependencyResolver;
 use Thunk\Verbs\Support\Reflector;

--- a/src/Support/DeferredWriteData.php
+++ b/src/Support/DeferredWriteData.php
@@ -4,10 +4,8 @@ namespace Thunk\Verbs\Support;
 
 class DeferredWriteData
 {
-public function __construct(
-    public ?string $class_name,
-    public string|null $unique_by,
-)
-{
-}
+    public function __construct(
+        public ?string $class_name,
+        public ?string $unique_by,
+    ) {}
 }

--- a/src/Support/DeferredWriteData.php
+++ b/src/Support/DeferredWriteData.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Thunk\Verbs\Support;
+
+class DeferredWriteData
+{
+public function __construct(
+    public ?string $class_name,
+    public string|null $unique_by,
+)
+{
+}
+}

--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -25,6 +25,7 @@ use Thunk\Verbs\Contracts\StoresEvents;
 use Thunk\Verbs\Contracts\StoresSnapshots;
 use Thunk\Verbs\Lifecycle\AutoCommitManager;
 use Thunk\Verbs\Lifecycle\Broker;
+use Thunk\Verbs\Lifecycle\DeferredWriteQueue;
 use Thunk\Verbs\Lifecycle\Dispatcher;
 use Thunk\Verbs\Lifecycle\EventStore;
 use Thunk\Verbs\Lifecycle\MetadataManager;
@@ -66,6 +67,7 @@ class VerbsServiceProvider extends PackageServiceProvider
         $this->app->scoped(EventQueue::class);
         $this->app->scoped(EventStateRegistry::class);
         $this->app->singleton(MetadataManager::class);
+        $this->app->singleton(DeferredWriteQueue::class);
 
         $this->app->scoped(StateManager::class, function (Container $app) {
             return new StateManager(

--- a/tests/Feature/LatestHandleTest.php
+++ b/tests/Feature/LatestHandleTest.php
@@ -6,7 +6,6 @@ use Thunk\Verbs\Commands\ReplayCommand;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Facades\Id;
 use Thunk\Verbs\Facades\Verbs;
-use Thunk\Verbs\Lifecycle\StateManager;
 use Thunk\Verbs\State;
 
 beforeEach(function () {
@@ -68,8 +67,7 @@ class LatestHandleTestEvent extends Event
     public function __construct(
         public int $add = 0,
         #[StateId(LatestHandleTestState::class)] public ?int $state_id = null,
-    ) {
-    }
+    ) {}
 
     public function apply(LatestHandleTestState $state)
     {
@@ -88,8 +86,7 @@ class AnotherLatestHandleTestEvent extends Event
     public function __construct(
         public int $add = 0,
         #[StateId(LatestHandleTestState::class)] public ?int $state_id = null,
-    ) {
-    }
+    ) {}
 
     public function apply(LatestHandleTestState $state)
     {

--- a/tests/Feature/LatestHandleTest.php
+++ b/tests/Feature/LatestHandleTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Attributes\Hooks\Latest;
+use Thunk\Verbs\Commands\ReplayCommand;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Id;
+use Thunk\Verbs\Facades\Verbs;
+use Thunk\Verbs\Lifecycle\StateManager;
+use Thunk\Verbs\State;
+
+beforeEach(function () {
+    $GLOBALS['replay_test_counts'] = [];
+    $GLOBALS['handle_count'] = 0;
+});
+
+it('prevents duplicate writes by uniqueBy', function () {
+    $state1_id = Id::make();
+    $state2_id = Id::make();
+
+    // State 1
+    LatestHandleTestEvent::fire(add: 2, state_id: $state1_id); // 2
+    LatestHandleTestEvent::fire(add: 2, state_id: $state1_id); // 4
+
+    // State 2
+    LatestHandleTestEvent::fire(add: 5, state_id: $state2_id); // 5
+    LatestHandleTestEvent::fire(add: 2, state_id: $state2_id); // 7
+
+    Verbs::commit();
+
+    expect($GLOBALS['handle_count'])->toBe(4);
+
+    $GLOBALS['handle_count'] = 0;
+
+    config(['app.env' => 'testing']);
+    $this->artisan(ReplayCommand::class);
+
+    expect($GLOBALS['handle_count'])->toBe(2);
+});
+
+it('prevents duplicate writes by uniqueBy and type', function () {
+    $state1_id = Id::make();
+    $state2_id = Id::make();
+
+    // State 1
+    LatestHandleTestEvent::fire(add: 2, state_id: $state1_id); // 2
+    AnotherLatestHandleTestEvent::fire(add: 2, state_id: $state1_id); // 4
+    AnotherLatestHandleTestEvent::fire(add: 2, state_id: $state1_id); // 6
+
+    // State 2
+    LatestHandleTestEvent::fire(add: 5, state_id: $state2_id); // 5
+    AnotherLatestHandleTestEvent::fire(add: 2, state_id: $state2_id); // 7
+
+    Verbs::commit();
+
+    expect($GLOBALS['handle_count'])->toBe(5);
+
+    $GLOBALS['handle_count'] = 0;
+
+    config(['app.env' => 'testing']);
+    $this->artisan(ReplayCommand::class);
+
+    expect($GLOBALS['handle_count'])->toBe(2);
+});
+
+class LatestHandleTestEvent extends Event
+{
+    public function __construct(
+        public int $add = 0,
+        #[StateId(LatestHandleTestState::class)] public ?int $state_id = null,
+    ) {
+    }
+
+    public function apply(LatestHandleTestState $state)
+    {
+        $state->count += $this->add;
+    }
+
+    #[Latest(unique_id: 'state_id')]
+    public function handle(): void
+    {
+        $GLOBALS['handle_count']++;
+    }
+}
+
+class AnotherLatestHandleTestEvent extends Event
+{
+    public function __construct(
+        public int $add = 0,
+        #[StateId(LatestHandleTestState::class)] public ?int $state_id = null,
+    ) {
+    }
+
+    public function apply(LatestHandleTestState $state)
+    {
+        $state->count += $this->add;
+    }
+
+    #[Latest(unique_id: 'state_id', type: LatestHandleTestEvent::class)]
+    public function handle(): void
+    {
+        $GLOBALS['handle_count']++;
+    }
+}
+
+class LatestHandleTestState extends State
+{
+    public int $count = 0;
+}


### PR DESCRIPTION
This attribute would give the ability to only write once per unique id.

This would allow heavy writes in the handle method, and only once would the write actually occur.

You could define something unique by a Model and model id, then it would only write to the model once the events have been replayed.