### PR TITLE
Provide a way to re-attach events on replay

### DIFF
--- a/src/Contracts/StoresEvents.php
+++ b/src/Contracts/StoresEvents.php
@@ -19,4 +19,7 @@ interface StoresEvents
 
     /** @param  Event[]  $events */
     public function write(array $events): bool;
+
+    /** @param  Event[]  $events */
+    public function reattach(array $events): bool;
 }

--- a/src/Lifecycle/EventStore.php
+++ b/src/Lifecycle/EventStore.php
@@ -47,6 +47,15 @@ class EventStore implements StoresEvents
             && VerbStateEvent::insert($this->formatRelationshipsForWrite($events));
     }
 
+    public function reattach(array $events): bool
+    {
+        if (empty($events)) {
+            return true;
+        }
+
+        return VerbStateEvent::insertOrIgnore($this->formatRelationshipsForWrite($events));
+    }
+
     protected function readEvents(
         ?State $state,
         Bits|UuidInterface|AbstractUid|int|string|null $after_id,

--- a/src/Testing/EventStoreFake.php
+++ b/src/Testing/EventStoreFake.php
@@ -57,6 +57,11 @@ class EventStoreFake implements StoresEvents
         return true;
     }
 
+    public function reattach(array $events): bool
+    {
+        return true;
+    }
+
     /** @return Collection<int, Event> */
     public function committed(string $class_name, ?Closure $filter = null): Collection
     {


### PR DESCRIPTION
Sometimes events don't need state at first but eventually do. This adds a simple way to "re-attach" all the events state during replay, effectively ensuring that everything with a `#[StateId]` attribute now is connected to that state for future queries. Imagine:

```php
class UserRegistered extends Event
{
  public int $user_id;
  public int $name;
}
```

And later needing to track some sort of "legacy rules" value for future events:

```php
class UserRegistered extends Event
{
  #[StateId(UserState::class)]
  public int $user_id;
  public int $name;

  public function apply(UserState $state)
  {
    $state->legacy_rules_apply = now()->isBefore('2024-01-01');
  }
}
```

With this feature, you can run replays with the `--reattach` flag, and old events that were fired before we updated our code with `#[StateId(UserState::class)]` will automatically get attached to the `UserState` before replay.