### PR TITLE
Allow for listening for parent classes or interfaces

### DIFF
--- a/src/Attributes/Hooks/Apply.php
+++ b/src/Attributes/Hooks/Apply.php
@@ -20,6 +20,6 @@ class Apply implements HookAttribute
 
     public function applyToHook(Hook $hook): void
     {
-        $hook->states[] = $this->state_type;
+        $hook->targets[] = $this->state_type;
     }
 }

--- a/src/Attributes/Hooks/Listen.php
+++ b/src/Attributes/Hooks/Listen.php
@@ -20,6 +20,6 @@ class Listen implements HookAttribute
 
     public function applyToHook(Hook $hook): void
     {
-        $hook->events[] = $this->event_type;
+        $hook->targets[] = $this->event_type;
     }
 }

--- a/src/Lifecycle/Dispatcher.php
+++ b/src/Lifecycle/Dispatcher.php
@@ -24,11 +24,8 @@ class Dispatcher
     public function register(object $target): void
     {
         foreach (Reflector::getHooks($target) as $hook) {
-            foreach ($hook->events as $event_type) {
-                $this->hooks[$event_type][] = $hook;
-            }
-            foreach ($hook->states as $state_type) {
-                $this->hooks[$state_type][] = $hook;
+            foreach ($hook->targets as $fqcn) {
+                $this->hooks[$fqcn][] = $hook;
             }
         }
     }
@@ -166,7 +163,9 @@ class Dispatcher
     /** @return Collection<int, Hook> */
     protected function hooksFor(Event|State $target, ?Phase $phase = null): Collection
     {
-        return Collection::make($this->hooks[$target::class] ?? [])
+        return Collection::make($this->hooks)
+            ->only(Reflector::getClassInstanceOf($target))
+            ->flatten()
             ->when($phase, fn (Collection $hooks) => $hooks->filter(fn (Hook $hook) => $hook->runsInPhase($phase)));
     }
 

--- a/src/Lifecycle/Hook.php
+++ b/src/Lifecycle/Hook.php
@@ -22,8 +22,7 @@ class Hook
 
         $hook = new static(
             callback: Closure::fromCallable([$target, $method->getName()]),
-            events: Reflector::getEventParameters($method),
-            states: Reflector::getStateParameters($method),
+            targets: Reflector::getParameterTypes($method),
             name: $method->getName(),
         );
 
@@ -34,8 +33,7 @@ class Hook
     {
         $hook = new static(
             callback: $callback,
-            events: Reflector::getEventParameters($callback),
-            states: Reflector::getStateParameters($callback),
+            targets: Reflector::getParameterTypes($callback),
         );
 
         return Reflector::applyHookAttributes($callback, $hook);
@@ -43,8 +41,7 @@ class Hook
 
     public function __construct(
         public Closure $callback,
-        public array $events = [],
-        public array $states = [],
+        public array $targets = [],
         public SplObjectStorage $phases = new SplObjectStorage,
         public ?string $name = null,
     ) {}

--- a/tests/Feature/HooksClassHierarchyTest.php
+++ b/tests/Feature/HooksClassHierarchyTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Thunk\Verbs\Attributes\Hooks\On;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Lifecycle\Dispatcher;
+use Thunk\Verbs\Lifecycle\Phase;
+
+it('can match events by type-hinting a specific class', function () {
+    app(Dispatcher::class)->register(new HooksClassHierarchyTestOneListener);
+
+    expect(fn () => HooksClassHierarchyTestEvent1::fire())->toThrow(RuntimeException::class, 'one')
+        ->and(fn () => HooksClassHierarchyTestEvent2::fire())->not->toThrow(RuntimeException::class);
+});
+
+it('can match events by type-hinting an interface', function () {
+    app(Dispatcher::class)->register(new HooksClassHierarchyTestInterfaceListener);
+
+    expect(fn () => HooksClassHierarchyTestEvent1::fire())->not->toThrow(RuntimeException::class)
+        ->and(fn () => HooksClassHierarchyTestEvent2::fire())->toThrow(RuntimeException::class, 'interface');
+});
+
+it('can match all events by type-hinting the base class', function () {
+    app(Dispatcher::class)->register(new HooksClassHierarchyTestEveryListener);
+
+    expect(fn () => HooksClassHierarchyTestEvent1::fire())->toThrow(RuntimeException::class, 'every')
+        ->and(fn () => HooksClassHierarchyTestEvent2::fire())->toThrow(RuntimeException::class, 'every');
+});
+
+interface HooksClassHierarchyTestInterface {}
+
+class HooksClassHierarchyTestEvent1 extends Event {}
+
+class HooksClassHierarchyTestEvent2 extends Event implements HooksClassHierarchyTestInterface {}
+
+class HooksClassHierarchyTestOneListener
+{
+    #[On(Phase::Validate)]
+    public static function one(HooksClassHierarchyTestEvent1 $event)
+    {
+        throw new RuntimeException('one');
+    }
+}
+
+class HooksClassHierarchyTestInterfaceListener
+{
+    #[On(Phase::Validate)]
+    public static function interface(HooksClassHierarchyTestInterface $event)
+    {
+        throw new RuntimeException('interface');
+    }
+}
+
+class HooksClassHierarchyTestEveryListener
+{
+    #[On(Phase::Validate)]
+    public static function every(Event $event)
+    {
+        throw new RuntimeException('every');
+    }
+}


### PR DESCRIPTION
Right now, Verbs looks up hooks specifically by the class name. So if you have a listener that listens for the root `Event` class, or an interface that your events implement, Verbs will not know to trigger it. This PR adds support for any of those scenarios:

```php
interface IsSpecialEvent {}

class NormalEvent extends Event {}

class SpecialEvent extends Event implements IsSpecialEvent {}

class MyListener
{
    public function listenForJustNormalEvent(NormalEvent $event)
    {
        // Only gets triggered when the `NormalEvent` class is fired
    }

    public function listenForAnySpecialEvent(IsSpecialEvent $event)
    {
        // Gets triggered when any event that implements `IsSpecialEvent`
    }

    public function listenForAllEvents(Event $event)
    {
        // Gets triggered when on all events
    }
}
```