### PR TITLE
Move modular to a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "php": ">=8.1",
         "glhd/bits": ">=0.3.0",
         "illuminate/contracts": "^10.34|^11.0",
-        "internachi/modular": "^2.0",
         "laravel/prompts": "^0.1.15|^0.2|^0.3",
         "spatie/laravel-package-tools": "^1.14.0",
         "symfony/property-access": "^6.2|^7.0",
@@ -28,6 +27,7 @@
     },
     "require-dev": {
         "brick/money": "^0.8.1",
+        "internachi/modular": "^2.2",
         "laravel/pint": "^1.13",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^7.10|^8.1",


### PR DESCRIPTION
This should address #194 — I'm honestly not sure why it wasn't a dev dependency before.