### PR TITLE
Add tag filtering support for event replay

### DIFF
--- a/src/Attributes/Hooks/Tag.php
+++ b/src/Attributes/Hooks/Tag.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Thunk\Verbs\Attributes\Hooks;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Tag
+{
+    /** @var string[] */
+    public array $tags;
+
+    public function __construct(string|array $tag)
+    {
+        $this->tags = is_array($tag) ? $tag : [$tag];
+    }
+}

--- a/src/Contracts/BrokersEvents.php
+++ b/src/Contracts/BrokersEvents.php
@@ -14,5 +14,5 @@ interface BrokersEvents
 
     public function isValid(Event $event): bool;
 
-    public function replay(?callable $beforeEach = null, ?callable $afterEach = null);
+    public function replay(?callable $beforeEach = null, ?callable $afterEach = null, ?array $tags = null);
 }

--- a/src/Lifecycle/Broker.php
+++ b/src/Lifecycle/Broker.php
@@ -77,9 +77,10 @@ class Broker implements BrokersEvents
         return $this->commit();
     }
 
-    public function replay(?callable $beforeEach = null, ?callable $afterEach = null): void
+    public function replay(?callable $beforeEach = null, ?callable $afterEach = null, ?array $tags = null): void
     {
         $this->is_replaying = true;
+        $this->replay_include_tags = $tags;
 
         try {
             $this->states->reset(include_storage: true);
@@ -110,6 +111,7 @@ class Broker implements BrokersEvents
             $this->states->writeSnapshots();
             $this->states->prune();
             $this->states->setReplaying(false);
+            $this->replay_include_tags = null;
             $this->is_replaying = false;
         }
     }

--- a/src/Lifecycle/BrokerConvenienceMethods.php
+++ b/src/Lifecycle/BrokerConvenienceMethods.php
@@ -18,6 +18,8 @@ trait BrokerConvenienceMethods
 {
     public bool $is_replaying = false;
 
+    public ?array $replay_include_tags = null;
+
     /**
      * @deprecated
      * @see IdManager

--- a/src/Lifecycle/Dispatcher.php
+++ b/src/Lifecycle/Dispatcher.php
@@ -118,11 +118,7 @@ class Dispatcher
     {
         $hooks = $this->hooksFor($event, Phase::Handle);
 
-        if (method_exists($event, 'handle')) {
-            $hooks->prepend(Hook::fromClassMethod($event, 'handle')->forcePhases(Phase::Handle, Phase::Replay));
-        }
-
-        return $hooks;
+        return $hooks->merge($this->hooksWithPrefix($event, Phase::Handle, 'handle'));
     }
 
     /** @return Collection<int, Hook> */
@@ -130,11 +126,7 @@ class Dispatcher
     {
         $hooks = $this->hooksFor($event, Phase::Replay);
 
-        if (method_exists($event, 'handle')) {
-            $hooks->prepend(Hook::fromClassMethod($event, 'handle')->forcePhases(Phase::Handle, Phase::Replay));
-        }
-
-        return $hooks;
+        return $hooks->merge($this->hooksWithPrefix($event, Phase::Replay, 'handle'));
     }
 
     /** @return Collection<int, Hook> */

--- a/src/Lifecycle/Hook.php
+++ b/src/Lifecycle/Hook.php
@@ -59,7 +59,9 @@ class Hook
     public function forcePhases(Phase ...$phases): static
     {
         foreach ($phases as $phase) {
-            $this->phases[$phase] = true;
+            if (! isset($this->phases[$phase])) {
+                $this->phases[$phase] = true;
+            }
         }
 
         return $this;

--- a/src/Testing/BrokerFake.php
+++ b/src/Testing/BrokerFake.php
@@ -72,9 +72,9 @@ class BrokerFake implements BrokersEvents
         return $this->broker->commit();
     }
 
-    public function replay(?callable $beforeEach = null, ?callable $afterEach = null)
+    public function replay(?callable $beforeEach = null, ?callable $afterEach = null, ?array $tags = null)
     {
-        $this->broker->replay($beforeEach, $afterEach);
+        $this->broker->replay($beforeEach, $afterEach, $tags);
     }
 
     public function commitImmediately(bool $commit_immediately = true): void

--- a/tests/Feature/ReplayCommandTest.php
+++ b/tests/Feature/ReplayCommandTest.php
@@ -3,6 +3,7 @@
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Carbon;
 use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Attributes\Hooks\Once;
 use Thunk\Verbs\Attributes\Hooks\Tag;
 use Thunk\Verbs\Commands\ReplayCommand;
 use Thunk\Verbs\Event;
@@ -46,7 +47,7 @@ it('can replay events', function () {
         ->toBe(4)
         ->and($GLOBALS['replay_test_counts'][$state2_id])
         ->toBe(4)
-        ->and($GLOBALS['handle_count'])->toBe(10);
+        ->and($GLOBALS['handle_count'])->toBe(10 * 2);
 
     // Reset 'projected' state and change data that only is touched when not replaying
     $GLOBALS['replay_test_counts'] = [];
@@ -240,6 +241,12 @@ class ReplayCommandTestEvent extends Event
         $GLOBALS['replay_test_counts'][$this->state_id] -= $this->subtract;
 
         Verbs::unlessReplaying(fn () => $GLOBALS['handle_count']++);
+    }
+
+    #[Once]
+    public function handleTwo()
+    {
+        $GLOBALS['handle_count']++;
     }
 }
 

--- a/tests/Feature/ReplayCommandTest.php
+++ b/tests/Feature/ReplayCommandTest.php
@@ -3,6 +3,7 @@
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Carbon;
 use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Attributes\Hooks\Tag;
 use Thunk\Verbs\Commands\ReplayCommand;
 use Thunk\Verbs\Event;
 use Thunk\Verbs\Facades\Id;
@@ -63,6 +64,13 @@ it('can replay events', function () {
         ->and($GLOBALS['replay_test_counts'][$state2_id])
         ->toBe(4)
         ->and($GLOBALS['handle_count'])->toBe(1337);
+});
+
+it('can replay with no events', function () {
+    config(['app.env' => 'testing']);
+    $this->artisan(ReplayCommand::class);
+
+    expect(Thunk\Verbs\Models\VerbEvent::count())->toBe(0);
 });
 
 it('uses the original event times when replaying', function () {
@@ -136,6 +144,81 @@ it('creates new snapshots when replaying', function () {
     expect($snapshot2->created_at)->toEqual(CarbonImmutable::parse('2024-05-15 18:00:00'));
 });
 
+it('can filter replayed events by tags', function () {
+    $GLOBALS['email_sent'] = [];
+    $GLOBALS['notification_sent'] = [];
+    $GLOBALS['billing_processed'] = [];
+
+    // Fire events with different tagged methods
+    TaggedReplayEvent::fire(state_id: Id::make());
+    TaggedReplayEvent::fire(state_id: Id::make());
+    TaggedReplayEvent::fire(state_id: Id::make());
+
+    Verbs::commit();
+
+    // Verify initial state
+    expect($GLOBALS['email_sent'])->toHaveCount(3)
+        ->and($GLOBALS['notification_sent'])->toHaveCount(3)
+        ->and($GLOBALS['billing_processed'])->toHaveCount(3);
+
+    // Reset counters
+    $GLOBALS['email_sent'] = [];
+    $GLOBALS['notification_sent'] = [];
+    $GLOBALS['billing_processed'] = [];
+
+    // Test single tag filter
+    config(['app.env' => 'testing']);
+    $this->artisan(ReplayCommand::class, ['--tag' => ['email']]);
+
+    expect($GLOBALS['email_sent'])->toHaveCount(3)
+        ->and($GLOBALS['notification_sent'])->toHaveCount(0)
+        ->and($GLOBALS['billing_processed'])->toHaveCount(0);
+
+    // Reset counters
+    $GLOBALS['email_sent'] = [];
+    $GLOBALS['notification_sent'] = [];
+    $GLOBALS['billing_processed'] = [];
+
+    // Test multiple tags
+    $this->artisan(ReplayCommand::class, ['--tag' => ['email', 'billing']]);
+
+    expect($GLOBALS['email_sent'])->toHaveCount(3)
+        ->and($GLOBALS['notification_sent'])->toHaveCount(0)
+        ->and($GLOBALS['billing_processed'])->toHaveCount(3);
+
+    // Reset counters
+    $GLOBALS['email_sent'] = [];
+    $GLOBALS['notification_sent'] = [];
+    $GLOBALS['billing_processed'] = [];
+
+    // Test with important tag
+    $this->artisan(ReplayCommand::class, ['--tag' => ['important']]);
+
+    expect($GLOBALS['email_sent'])->toHaveCount(0)
+        ->and($GLOBALS['notification_sent'])->toHaveCount(0)
+        ->and($GLOBALS['billing_processed'])->toHaveCount(3);
+});
+
+it('handles case sensitivity in tags correctly', function () {
+    $GLOBALS['email_sent'] = [];
+    $GLOBALS['notification_sent'] = [];
+    $GLOBALS['billing_processed'] = [];
+
+    TaggedReplayEvent::fire(state_id: Id::make());
+    Verbs::commit();
+
+    $GLOBALS['email_sent'] = [];
+    $GLOBALS['notification_sent'] = [];
+    $GLOBALS['billing_processed'] = [];
+
+    config(['app.env' => 'testing']);
+    $this->artisan(ReplayCommand::class, ['--tag' => ['EMAIL']]);
+
+    expect($GLOBALS['email_sent'])->toHaveCount(1)
+        ->and($GLOBALS['notification_sent'])->toHaveCount(0)
+        ->and($GLOBALS['billing_processed'])->toHaveCount(0);
+});
+
 class ReplayCommandTestEvent extends Event
 {
     public function __construct(
@@ -185,4 +268,34 @@ class ReplayCommandTestWormholeEvent extends Event
 class ReplayCommandTestWormholeState extends State
 {
     public CarbonImmutable $time;
+}
+
+class TaggedReplayEvent extends Event
+{
+    public function __construct(
+        #[StateId(TaggedReplayState::class)] public ?int $state_id = null,
+    ) {}
+
+    #[Tag('email')]
+    public function handleSendEmail()
+    {
+        $GLOBALS['email_sent'][] = $this->id;
+    }
+
+    #[Tag('notification')]
+    public function handleSendNotification()
+    {
+        $GLOBALS['notification_sent'][] = $this->id;
+    }
+
+    #[Tag(['billing', 'important'])]
+    public function handleProcessBilling()
+    {
+        $GLOBALS['billing_processed'][] = $this->id;
+    }
+}
+
+class TaggedReplayState extends State
+{
+    public int $count = 0;
 }


### PR DESCRIPTION
Added the ability to filter event replay by tags. This allows replaying only specific types of events based on their tags.

Changes include:
- New `Tag` attribute for marking event handlers with one or more tags
- Added `--tag` option to `verbs:replay` command
- Tags are case-insensitive
- Enabled prefixing for handle methods


Example usage:

```php
// Single tag
#[Tag('email')]
public function handleSendEmail() { ... }

// Multiple tags
#[Tag(['billing', 'important'])] 
public function handleProcessBilling() { ... }
```

// CLI usage:
verbs:replay --tag=email
verbs:replay --tag=email --tag=billing
