### PR TITLE
updates to custom factory docs

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -80,7 +80,7 @@ choosing by setting an `$intial_event` property on your State Factory.
 ```php
 class ExampleStateFactory extends StateFactory
 {
-    protected $initial_event = ExampleCreated::class;
+    protected string $initial_event = ExampleCreated::class;
 }
 ```
 
@@ -132,7 +132,7 @@ UserState::factory()->create([ /* state data */ ]);
 
 Verbs makes it possible to create your own custom factories for your states.
 
-Create an `ExampleStateFactory` class in a new `App/States/Factory` folder.
+Create an `ExampleStateFactory` class in a new `App/States/Factories` folder.
 
 ```php
 namespace App\States\Factories;


### PR DESCRIPTION
Updates the custom factory and initialized event examples to use the correct syntax.

- The docs recommended placing factories within a new `App/States/Factory` folder, but the example used `App/States/Factories` -- updated both to be `App/States/Factories`

- The `$initial_event` example was `protected` but the `StateFactory` class wants a `protected string`