### PR TITLE
Docs: Update ids.md

### DIFF
--- a/docs/ids.md
+++ b/docs/ids.md
@@ -25,9 +25,12 @@ class JobApplication extends Model
     use HasSnowflakes; // Add this to your model
 
     // Any attribute can be cast to a `Snowflake` (or `Sonyflake`)
-    protected $casts = [
-        'id' => Snowflake::class,
-    ];
+    protected function casts(): array
+    {
+        return [
+            'id' => Snowflake::class,
+        ];
+    }
 }
 ```
 


### PR DESCRIPTION
Update the `casts()` method to the new Laravel style. In a recent version of Laravel they swapped from the array syntax to the function syntax. AFAIK the array syntax still works but is no longer mentioned in the documentation.
https://laravel.com/docs/11.x/eloquent-mutators#attribute-casting