### PR TITLE
Improving the "Generating a State" Command in the State Documentation

### DIFF
--- a/docs/states.md
+++ b/docs/states.md
@@ -24,7 +24,7 @@ happened.
 To generate a state, use the built-in artisan command:
 
 ```shell
-php artisan verbs:state GameState
+php artisan verbs:state ExampleState
 ```
 
 When you create your first state, it will generate in a fresh `app/States` directory.


### PR DESCRIPTION
Hello 

The [documentation provides](https://verbs.thunk.dev/docs/reference/states#content-generating-a-state) an example of how to generate a verb state using the command line. Currently, it uses `GameState` as an example, but in the following code block, `ExampleState` is used to demonstrate the default structure of a newly created state file.

To maintain consistency and clarity, I propose updating the command example from:  

```bash
php artisan verbs:state GameState
```
to:  
```bash
php artisan verbs:state ExampleState
```
This change ensures that the documentation remains clear and consistent, improving readability for users following the guide.

Thanks. 