### PR TITLE
Fix use Response::allowed to return a bool value as specified in the return type

### DIFF
--- a/src/Lifecycle/Guards.php
+++ b/src/Lifecycle/Guards.php
@@ -64,7 +64,9 @@ class Guards
             $result = call_user_func_array([$this->event, 'authorize'], $resolver());
 
             if ($result instanceof Response) {
-                return $result->authorize();
+                $response = $result->authorize();
+
+                return $response->allowed();
             }
 
             if (is_bool($result)) {


### PR DESCRIPTION
This PR addresses an issue in the `Guards::passesAuthorization` method where the `Response` object was not using the `allowed()` method to return a boolean value and instead returned a Response object. 

The fix ensures that the method adheres to its specified `bool` return type by explicitly calling `$response->allowed()`.
