### PR TITLE
[ BugFix ] adds missing dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "illuminate/contracts": "^10.34|^11.0|^12.0",
         "internachi/modular": "^2.0",
         "laravel/prompts": "^0.1.15|^0.2|^0.3",
+        "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
         "spatie/laravel-package-tools": "^1.14.0",
         "symfony/property-access": "^6.2|^7.0",
         "symfony/serializer": "^6.3|^7.0"


### PR DESCRIPTION
There’s a bug in our dependencies
Our Cloud deployments are blowing up because of an unmet dep (using --no-dev).

We’re not finding two classes that are being used in the [VerbsServiceProvider](https://github.com/hirethunk/verbs/blob/ac2b2a54109be7172ba5cc887083afdcc4ce3658/src/VerbsServiceProvider.php#L114)

They’re from a package called phpdocumentor/reflection-docblock which is a dep of symfony/serializer, but it’s been moved into their require-dev. We should require this package explicitly to fix it.