### PR TITLE
`State::new()` now uses the configured ID type

### DIFF
--- a/src/State.php
+++ b/src/State.php
@@ -11,6 +11,7 @@ use Symfony\Component\Uid\AbstractUid;
 use Thunk\Verbs\Contracts\StoresEvents;
 use Thunk\Verbs\Exceptions\StateNotFoundException;
 use Thunk\Verbs\Lifecycle\StateManager;
+use Thunk\Verbs\Support\IdManager;
 use Thunk\Verbs\Support\Serializer;
 use Thunk\Verbs\Support\StateCollection;
 
@@ -56,7 +57,7 @@ abstract class State implements UrlRoutable
 
     public static function new()
     {
-        return static::load(snowflake()->make());
+        return static::load(app(IdManager::class)->make());
     }
 
     public static function loadOrFail($from): static

--- a/tests/Feature/StateIdGenerationTest.php
+++ b/tests/Feature/StateIdGenerationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
+use Thunk\Verbs\State;
+use Thunk\Verbs\Support\IdManager;
+
+test('state new respects the configured id type', function ($type, callable $check) {
+    Config::set('verbs.id_type', $type);
+
+    App::forgetInstance(IdManager::class);
+
+    $state = StateIdGenerationTestState::new();
+
+    expect($state)
+        ->toBeInstanceOf(StateIdGenerationTestState::class)
+        ->toHaveProperty('id')
+        ->and($check((string) $state->id))->toBeTrue();
+})->with([
+    'ulid' => ['ulid', [Str::class, 'isUlid']],
+    'uuid' => ['uuid', [Str::class, 'isUuid']],
+    'snowflake' => ['snowflake', 'validate_snowflake'],
+]);
+
+function validate_snowflake($value): bool
+{
+    return preg_match('/^[1-9][0-9]{17}$/', $value);
+}
+
+class StateIdGenerationTestState extends State {}


### PR DESCRIPTION
Calling `SomeState::new()` was previously always using `snowflake()->make()` regardless of the configured `id_type`.

This PR alters the sate base class to use the ID manager to generate new IDs.