### PR TITLE
Add event map

### DIFF
--- a/src/Exceptions/EventMapViolationException.php
+++ b/src/Exceptions/EventMapViolationException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Thunk\Verbs\Exceptions;
+
+use RuntimeException;
+use Thunk\Verbs\Event;
+
+class EventMapViolationException extends RuntimeException
+{
+    /**
+     * The name of the affected event.
+     */
+    public string $event;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  class-string<Event>  $event
+     */
+    public function __construct(string $event)
+    {
+        parent::__construct("No alias defined for event [{$event}].");
+
+        $this->event = $event;
+    }
+}

--- a/src/Lifecycle/EventStore.php
+++ b/src/Lifecycle/EventStore.php
@@ -125,7 +125,7 @@ class EventStore implements StoresEvents
     {
         return array_map(fn (Event $event) => [
             'id' => Id::from($event->id),
-            'type' => $event::class,
+            'type' => Event::getAlias($event::class),
             'data' => app(Serializer::class)->serialize($event),
             'metadata' => app(Serializer::class)->serialize($this->metadata->get($event)),
             'created_at' => app(MetadataManager::class)->getEphemeral($event, 'created_at', now()),

--- a/src/Support/Serializer.php
+++ b/src/Support/Serializer.php
@@ -41,6 +41,7 @@ class Serializer
         string|array $data,
         bool $call_constructor = false,
     ) {
+        $target = is_string($target) ? (Event::getMappedEvent($target) ?? $target) : $target;
         $type = $target;
         $context = $this->context;
 

--- a/tests/Feature/EventMapTest.php
+++ b/tests/Feature/EventMapTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+
+it('can store and restore an event with and without alias', function () {
+    Event::eventMap([
+        'with-alias' => EventMapEventWithAlias::class,
+    ]);
+
+    EventMapEventWithAlias::fire();
+    EventMapEvent::fire();
+
+    Verbs::commit();
+
+    [$eventWithAlias, $eventWithoutAlias] = \Thunk\Verbs\Models\VerbEvent::all();
+
+    expect($eventWithAlias)
+        ->type->toBe('with-alias')
+        ->event()->toBeInstanceOf(EventMapEventWithAlias::class);
+
+    expect($eventWithoutAlias)
+        ->type->toBe(EventMapEvent::class)
+        ->event()->toBeInstanceOf(EventMapEvent::class);
+});
+
+test('using an event without an entry in the event map throws an exception when event map is required', function () {
+    Event::eventMap([
+        'with-alias' => EventMapEventWithAlias::class,
+    ]);
+    EventMapEvent::requireEventMap();
+
+    EventMapEvent::fire();
+
+    Verbs::commit();
+})
+    ->throws(\Thunk\Verbs\Exceptions\EventMapViolationException::class, 'No alias defined for event [EventMapEvent].')
+    ->after(fn () => EventMapEvent::requireEventMap(false));
+
+class EventMapEventWithAlias extends Event {}
+
+class EventMapEvent extends Event {}


### PR DESCRIPTION
This PR introduces an event alias map similar to Laravels [MorphMap](https://laravel.com/docs/12.x/eloquent-relationships#custom-polymorphic-types).

## Motivation
When an alias for an event class is defined, the alias is stored in the `type` attribute of the events instead of the fully qualified class name. This has two main benefits:
- The event type is more readable. For example, instead of `App\Events\Users\UserCreated` just `user::created`
- Refactoring the event class (renaming; changing namespace) does not require an updated of previously stored events

## Usage
The behaviour is similar to Laravels MorphMap.

Define the event map in one or more service providers:
```php
// AppServiceProvider.php
use Thunk\Verbs\Event;
use App\Events\Users\UserCreated;

Event::eventMap([
    'user::created' => UserCreated::class,
]);
```

If you want to ensure every event has an alias defined:
```php
// AppServiceProvider.php
use Thunk\Verbs\Event;

Event::requireEventMap();
```

After defining the map, events are used as before:
```php
use App\Events\Users\UserCreated;

UserCreated::fire(...);
```

## Backwards compatibility
Even I would not recommend it, it would be possible to start using the event map even some events have been stored before. Restoring an event from the database works regardless if the `type` is an alias or a fully qualified class name.
But this would prevent you from refactoring the event class as mentioned above.