### PR TITLE
Remove unnecessary updated_at field from events tables

### DIFF
--- a/database/migrations/2024_04_16_115559_create_verb_events_table.php
+++ b/database/migrations/2024_04_16_115559_create_verb_events_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->json('data');
             $table->json('metadata');
 
-            $table->timestamps();
+            $table->timestamp('created_at')->nullable();
         });
     }
 

--- a/database/migrations/2024_04_16_115559_create_verb_state_events_table.php
+++ b/database/migrations/2024_04_16_115559_create_verb_state_events_table.php
@@ -25,7 +25,7 @@ return new class extends Migration
 
             $table->string('state_type')->index();
 
-            $table->timestamps();
+            $table->timestamp('created_at')->nullable();
         });
     }
 

--- a/src/Lifecycle/EventStore.php
+++ b/src/Lifecycle/EventStore.php
@@ -129,7 +129,6 @@ class EventStore implements StoresEvents
             'data' => app(Serializer::class)->serialize($event),
             'metadata' => app(Serializer::class)->serialize($this->metadata->get($event)),
             'created_at' => app(MetadataManager::class)->getEphemeral($event, 'created_at', now()),
-            'updated_at' => now(),
         ], $event_objects);
     }
 
@@ -143,7 +142,6 @@ class EventStore implements StoresEvents
                 'state_id' => Id::from($state->id),
                 'state_type' => $state::class,
                 'created_at' => now(),
-                'updated_at' => now(),
             ]))
             ->values()
             ->all();

--- a/src/Models/VerbEvent.php
+++ b/src/Models/VerbEvent.php
@@ -12,6 +12,8 @@ use Thunk\Verbs\Support\Serializer;
 
 class VerbEvent extends Model
 {
+    public const UPDATED_AT = null;
+
     public $guarded = [];
 
     protected $casts = [

--- a/src/Models/VerbStateEvent.php
+++ b/src/Models/VerbStateEvent.php
@@ -7,6 +7,8 @@ use Thunk\Verbs\State;
 
 class VerbStateEvent extends Model
 {
+    public const UPDATED_AT = null;
+
     public $guarded = [];
 
     public function getConnectionName()


### PR DESCRIPTION
The updated_at field in the events and events_state pivot tables are unnecessary since this are/should be immutable entries. Makes sense to remove it. Thinking about huge tables this could save a bit space.