### PR TITLE
Configurable options for authorization/validation checks during replays

### DIFF
--- a/config/verbs.php
+++ b/config/verbs.php
@@ -100,6 +100,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Replay
+    |--------------------------------------------------------------------------
+    |
+    | By default, Verbs will not perform authorization and validation checks
+    | when replaying events. If you would like, you can enable these checks.
+    |
+    */
+    'replay' => [
+        'authorization' => false,
+        'validation' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Wormhole
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
When replaying events there are cases where it's beneficial to perform authorization and validation checks. This PR introduces new options in config that allows just that.

### Case for authorization:
Let's imagine a hypothetical event `PostDeleted`. Inside `authorize()` method we perform a check that only admins can delete posts. Now because of a bug elsewhere in the system, a user managed to obtain admin role and deletes a bunch of posts. After fixing said bug, we could replay the events, but by default the posts would still get deleted. However, if authorization checks were performed, we would see these events being ignored and posts remain not deleted.

### Case for validation:
Let's say we have an event called `PlayerBoughtItem`. Inside `validate()` method we perform a check to see if player has enough money in his account. Now because of a bug elsewhere in the system, a player could "cheat" in money and buy items they would not have been able to afford otherwise. After fixing said, bug we could replay the events, but by default the transactions would still take place (and player would potentially have a negative balance), However, if validation checks were performed, we would see these events being ignored and "illegal" transactions would not take place.

Current solution for this would be to include same authorization/validation checks inside apply/handle methods. This does however introduce code/logic duplication.