### PR TITLE
Prevent modification of the Symfony serializer

### DIFF
--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -97,8 +97,16 @@ class VerbsServiceProvider extends PackageServiceProvider
         });
 
         $this->app->singleton(Serializer::class, function (Container $app) {
+            $config = $app->make(Repository::class);
+
             return new Serializer(
-                serializer: $app->make(SymfonySerializer::class),
+                serializer: new SymfonySerializer(
+                    normalizers: collect($config->get('verbs.normalizers'))
+                        ->map(fn ($class_name) => app($class_name))
+                        ->values()
+                        ->all(),
+                    encoders: [new JsonEncoder],
+                ),
                 context: $app->make(Repository::class)->get('verbs.serializer_context', []),
             );
         });
@@ -115,18 +123,6 @@ class VerbsServiceProvider extends PackageServiceProvider
                         new ReflectionExtractor,
                     ]),
                 classDiscriminatorResolver: new ClassDiscriminatorFromClassMetadata(new ClassMetadataFactory($loader)),
-            );
-        });
-
-        $this->app->singleton(SymfonySerializer::class, function (Container $app) {
-            $config = $app->make(Repository::class);
-
-            return new SymfonySerializer(
-                normalizers: collect($config->get('verbs.normalizers'))
-                    ->map(fn ($class_name) => app($class_name))
-                    ->values()
-                    ->all(),
-                encoders: [new JsonEncoder],
             );
         });
 


### PR DESCRIPTION
This PR fixes an issue, when Verbs is used in combination with the [API platform](https://github.com/api-platform/api-platform) package.

Problem: The API documentation generated by the API platform does not contain any endpoints.

Reason: The API platform makes use of the Symfony Serializer which is overridden by Verbs in the package service provider.

Solution: There is no need to override the Serializer. Instead, we can directly instantiate a new Serializer with the configuration required, when Verbs Serializer is resolved.