### PR TITLE
Replace `modular` with `modularize`

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,32 +12,19 @@ jobs:
   sqlite:
     runs-on: ${{ matrix.os }}-latest
 
-
-
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu, windows]
-        php: [8.3, 8.2, 8.1]
-        laravel: ['10.*', '11.*', '12.*']
-        stability: [stable, lowest]
-        exclude:
-          - php: 8.1
-            laravel: 11.*
-          - laravel: 12.*
-            php: 8.1
-
-
+        os: [ ubuntu, windows ]
+        php: [ 8.4, 8.3, 8.2 ]
+        laravel: [ 12.*, 11.*, 10.* ]
+        stability: [ stable, lowest ]
 
     name: ${{ matrix.os }}/sqlite P${{ matrix.php }}:L${{ matrix.laravel }} (${{ matrix.stability }})
-
-
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -46,21 +33,15 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, :php-psr
           coverage: none
 
-
-
       - name: Setup problem matchers
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-
-
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
           composer update --prefer-${{ matrix.stability }} --prefer-dist --no-interaction
-
-
 
       - name: Execute tests
         run: vendor/bin/pest
@@ -70,25 +51,15 @@ jobs:
   mysql:
     runs-on: ${{ matrix.os }}-latest
 
-
-
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu]
-        php: [8.3, 8.2, 8.1]
-        laravel: ['10.*', '11.*', '12.*']
-        stability: [lowest, stable]
-        exclude:
-          - php: 8.1
-            laravel: 11.*
-          - laravel: 12.*
-            php: 8.1
-
-
+        os: [ ubuntu, windows ]
+        php: [ 8.4, 8.3, 8.2 ]
+        laravel: [ 12.*, 11.*, 10.* ]
+        stability: [ stable, lowest ]
 
     name: ${{ matrix.os }}/mysql P${{ matrix.php }}:L${{ matrix.laravel }} (${{ matrix.stability }})
-
 
     services:
       mysql:
@@ -100,13 +71,9 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -115,21 +82,15 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, :php-psr
           coverage: none
 
-
-
       - name: Setup problem matchers
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-
-
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
           composer update --prefer-${{ matrix.stability }} --prefer-dist --no-interaction
-
-
 
       - name: Execute tests
         run: vendor/bin/pest
@@ -142,25 +103,15 @@ jobs:
   pgsql:
     runs-on: ${{ matrix.os }}-latest
 
-
-
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu]
-        php: [8.3, 8.2, 8.1]
-        laravel: ['10.*', '11.*', '12.*']
-        stability: [lowest, stable]
-        exclude:
-          - php: 8.1
-            laravel: 11.*
-          - laravel: 12.*
-            php: 8.1
-
-
+        os: [ ubuntu, windows ]
+        php: [ 8.4, 8.3, 8.2 ]
+        laravel: [ 12.*, 11.*, 10.* ]
+        stability: [ stable, lowest ]
 
     name: ${{ matrix.os }}/pgsql P${{ matrix.php }}:L${{ matrix.laravel }} (${{ matrix.stability }})
-
 
     services:
       postgresql:
@@ -173,13 +124,9 @@ jobs:
           - 5432:5432
         options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
 
-
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -188,21 +135,15 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, :php-psr
           coverage: none
 
-
-
       - name: Setup problem matchers
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-
-
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
           composer update --prefer-${{ matrix.stability }} --prefer-dist --no-interaction
-
-
 
       - name: Execute tests
         run: vendor/bin/pest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to `:package_name` will be documented in this file.
+See [Releases](https://github.com/hirethunk/verbs/releases) for an up-to-date changelog.
 
 ## 0.0.9 - 2024-02-15
 
@@ -8,7 +8,8 @@ All notable changes to `:package_name` will be documented in this file.
 
 * make pending event macroable by @jdiddydave in https://github.com/hirethunk/verbs/pull/55
 * Add `for` method to factory by @joshhanley in https://github.com/hirethunk/verbs/pull/56
-* Change state factory to not require an array to be passed in by @joshhanley in https://github.com/hirethunk/verbs/pull/57
+* Change state factory to not require an array to be passed in by @joshhanley
+  in https://github.com/hirethunk/verbs/pull/57
 * adding missing inheritance from docs by @da-mask in https://github.com/hirethunk/verbs/pull/58
 * Fix the stupidest type check ever. by @DanielCoulbourne in https://github.com/hirethunk/verbs/pull/59
 * Use "historical" `now()` when replaying events by @inxilpro in https://github.com/hirethunk/verbs/pull/29
@@ -34,19 +35,22 @@ All notable changes to `:package_name` will be documented in this file.
 
 ### What's Changed
 
-* Refactor event/pending event, and add a way to immediately commit an event by @inxilpro in https://github.com/hirethunk/verbs/pull/27
+* Refactor event/pending event, and add a way to immediately commit an event by @inxilpro
+  in https://github.com/hirethunk/verbs/pull/27
 * Add ability to include metadata on every event by @skylerkatz in https://github.com/hirethunk/verbs/pull/14
 * Make `fire` do nothing while replaying by @jdiddydave in https://github.com/hirethunk/verbs/pull/35
 * Fix typo in ids.md by @morpheus7CS in https://github.com/hirethunk/verbs/pull/39
 * Clean up serialization by @inxilpro in https://github.com/hirethunk/verbs/pull/45
 * Add id_type config by @jdiddydave in https://github.com/hirethunk/verbs/pull/44
 * Prevent model serialization by @inxilpro in https://github.com/hirethunk/verbs/pull/47
-* When deserializing, skip deserializing if source is already the destination type. by @DanielCoulbourne in https://github.com/hirethunk/verbs/pull/50
+* When deserializing, skip deserializing if source is already the destination type. by @DanielCoulbourne
+  in https://github.com/hirethunk/verbs/pull/50
 * Test Affordances by @DanielCoulbourne in https://github.com/hirethunk/verbs/pull/41
 * State aliases by @inxilpro in https://github.com/hirethunk/verbs/pull/48
 * Fix auto-discovery exception messages by @matthewpaulking in https://github.com/hirethunk/verbs/pull/49
 * Bump aglipanci/laravel-pint-action from 2.3.0 to 2.3.1 by @dependabot in https://github.com/hirethunk/verbs/pull/51
-* Add isAllowed() and isValid() methods for PendingEvent by @DanielCoulbourne in https://github.com/hirethunk/verbs/pull/52
+* Add isAllowed() and isValid() methods for PendingEvent by @DanielCoulbourne
+  in https://github.com/hirethunk/verbs/pull/52
 
 ### New Contributors
 
@@ -61,7 +65,8 @@ All notable changes to `:package_name` will be documented in this file.
 ### What's Changed
 
 * fix typo by @gpibarra in https://github.com/hirethunk/verbs/pull/18
-* Stop examples and workbench dirs being in the packagist repo by @morrislaptop in https://github.com/hirethunk/verbs/pull/23
+* Stop examples and workbench dirs being in the packagist repo by @morrislaptop
+  in https://github.com/hirethunk/verbs/pull/23
 * Add Livewire support to commit Verbs just before render by @joshhanley in https://github.com/hirethunk/verbs/pull/20
 * Remove redundant "it it" from unit tests by @markjaquith in https://github.com/hirethunk/verbs/pull/30
 * Remove phases from events by @inxilpro in https://github.com/hirethunk/verbs/pull/33
@@ -82,7 +87,8 @@ All notable changes to `:package_name` will be documented in this file.
 
 ### What's Changed
 
-- Add support for interfaces in the expectsParameters check on MethodFi… by @DanielCoulbourne in https://github.com/hirethunk/verbs/pull/19
+- Add support for interfaces in the expectsParameters check on MethodFi… by @DanielCoulbourne
+  in https://github.com/hirethunk/verbs/pull/19
 
 **Full Changelog**: https://github.com/hirethunk/verbs/compare/0.0.5...v0.0.6
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=8.1",
         "glhd/bits": ">=0.3.0",
         "illuminate/contracts": "^10.34|^11.0|^12.0",
-        "internachi/modular": "^2.0",
+        "internachi/modularize": "^1.0",
         "laravel/prompts": "^0.1.15|^0.2|^0.3",
         "spatie/laravel-package-tools": "^1.14.0",
         "symfony/property-access": "^6.2|^7.0",
@@ -28,6 +28,7 @@
     },
     "require-dev": {
         "brick/money": "^0.8.1|^0.10",
+        "internachi/modular": "^2.3",
         "laravel/pint": "^1.13",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^7.10|^8.1",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=8.1",
         "glhd/bits": ">=0.3.0",
         "illuminate/contracts": "^10.34|^11.0|^12.0",
-        "internachi/modularize": "^1.0",
+        "internachi/modularize": "^1.1.0",
         "laravel/prompts": "^0.1.15|^0.2|^0.3",
         "spatie/laravel-package-tools": "^1.14.0",
         "symfony/property-access": "^6.2|^7.0",

--- a/src/Commands/MakeVerbEventCommand.php
+++ b/src/Commands/MakeVerbEventCommand.php
@@ -2,13 +2,15 @@
 
 namespace Thunk\Verbs\Commands;
 
-use InterNACHI\Modularize\Modularize;
+use InterNACHI\Modularize\ModularizeGeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'verbs:event')]
 class MakeVerbEventCommand extends VerbGeneratorCommand
 {
-    use Modularize;
+    use ModularizeGeneratorCommand {
+        getDefaultNamespace as getModularizedNamespace;
+    }
 
     protected $name = 'verbs:event';
 

--- a/src/Commands/MakeVerbEventCommand.php
+++ b/src/Commands/MakeVerbEventCommand.php
@@ -2,15 +2,13 @@
 
 namespace Thunk\Verbs\Commands;
 
-use InterNACHI\Modular\Console\Commands\Make\Modularize;
+use InterNACHI\Modularize\Modularize;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'verbs:event')]
 class MakeVerbEventCommand extends VerbGeneratorCommand
 {
-    use Modularize {
-        getDefaultNamespace as getModularizedNamespace;
-    }
+    use Modularize;
 
     protected $name = 'verbs:event';
 

--- a/src/Commands/MakeVerbStateCommand.php
+++ b/src/Commands/MakeVerbStateCommand.php
@@ -2,7 +2,7 @@
 
 namespace Thunk\Verbs\Commands;
 
-use InterNACHI\Modular\Console\Commands\Make\Modularize;
+use InterNACHI\Modularize\Modularize;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'verbs:state')]

--- a/src/Commands/MakeVerbStateCommand.php
+++ b/src/Commands/MakeVerbStateCommand.php
@@ -2,13 +2,13 @@
 
 namespace Thunk\Verbs\Commands;
 
-use InterNACHI\Modularize\Modularize;
+use InterNACHI\Modularize\ModularizeGeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'verbs:state')]
 class MakeVerbStateCommand extends VerbGeneratorCommand
 {
-    use Modularize {
+    use ModularizeGeneratorCommand {
         getDefaultNamespace as getModularizedNamespace;
     }
 


### PR DESCRIPTION
We use `internachi/modular` in tests, but only need the `Modularize` trait for Verbs commands. This swaps out that dependency with the new `internachi/modularize` library that's specifically for this purpose.