### PR TITLE
feat: customizable handle return resolution logic

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -107,6 +107,23 @@ public function handle()
 }
 ```
 
+> [!warning]
+> The above example will only work consistently, if there are no other lifecycle hooks registered for your event.
+> Additional registered lifecycle hooks will lead to a collection of results being returned, instead of the singular return value of your event's `handle` method.
+> If your application relies on a different return behavior, you can globally define how commit results are resolved (for example, exclusively return the result of your event's `handle` method):
+> 
+> ```php
+> use Illuminate\Support\Collection;
+> use Thunk\Verbs\Event;
+> use Thunk\Verbs\Facades\Verbs;
+> 
+> Verbs::resolveHandleReturnUsing(
+>     fn (Collection $results, Event $event): Collection => $results->take(1)
+> );
+> ```
+>
+> _See [this issue](https://github.com/hirethunk/verbs/issues/213) that discusses the behavior of commit returns._
+
 ## `handle()`
 
 Use the `handle()` method included in your event to update your database / models / UI data.

--- a/src/Facades/Verbs.php
+++ b/src/Facades/Verbs.php
@@ -18,6 +18,7 @@ use Thunk\Verbs\Testing\EventStoreFake;
  * @method static Event fire(Event $event)
  * @method static void listen(string|object $listener)
  * @method static void createMetadataUsing(callable $callback)
+ * @method static void resolveHandleReturnUsing(?callable $callback = null)
  * @method static void commitImmediately(bool $commit_immediately = true)
  * @method static EventStoreFake assertCommitted(string|Closure $event, Closure|int|null $callback = null)
  * @method static EventStoreFake assertNotCommitted(string|Closure $event, ?Closure $callback = null)

--- a/src/Lifecycle/BrokerConvenienceMethods.php
+++ b/src/Lifecycle/BrokerConvenienceMethods.php
@@ -38,6 +38,11 @@ trait BrokerConvenienceMethods
         app(MetadataManager::class)->createMetadataUsing($callback);
     }
 
+    public function resolveHandleReturnUsing(?callable $callback = null): void
+    {
+        app(HandleReturnResolver::class)->using($callback);
+    }
+
     public function isAuthorized(Event $event): bool
     {
         try {

--- a/src/Lifecycle/Dispatcher.php
+++ b/src/Lifecycle/Dispatcher.php
@@ -79,7 +79,11 @@ class Dispatcher
             return collect();
         }
 
-        return $this->getHandleHooks($event)->map(fn (Hook $hook) => $hook->handle($this->container, $event));
+        $handleHookResults = $this->getHandleHooks($event)->map(fn (Hook $hook) => $hook->handle($this->container, $event));
+
+        return $this->container
+            ->make(HandleReturnResolver::class)
+            ->resolveResultsForEvent($handleHookResults, $event);
     }
 
     public function replay(Event $event): void

--- a/src/Lifecycle/HandleReturnResolver.php
+++ b/src/Lifecycle/HandleReturnResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Thunk\Verbs\Lifecycle;
+
+use Illuminate\Support\Collection;
+use Thunk\Verbs\Event;
+
+class HandleReturnResolver
+{
+    /** @var callable(Collection, Event): Collection */
+    private $resolver;
+
+    public function __construct()
+    {
+        $this->resolver = fn (Collection $results, Event $event) => $results;
+    }
+
+    public function using(?callable $resolver = null): void
+    {
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * NOTE: We are always expecting a Collection of results, because the PendingEvent::commit() method expects
+     * a Collection and conditionally returns either only the first result or the whole collection in case of
+     * multiple items.
+     *
+     * See issue discussing behavior of commit returns https://github.com/hirethunk/verbs/issues/213
+     */
+    public function resolveResultsForEvent(Collection $results, Event $event): Collection
+    {
+        return call_user_func($this->resolver, $results, $event);
+    }
+}

--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -29,6 +29,7 @@ use Thunk\Verbs\Lifecycle\AutoCommitManager;
 use Thunk\Verbs\Lifecycle\Broker;
 use Thunk\Verbs\Lifecycle\Dispatcher;
 use Thunk\Verbs\Lifecycle\EventStore;
+use Thunk\Verbs\Lifecycle\HandleReturnResolver;
 use Thunk\Verbs\Lifecycle\MetadataManager;
 use Thunk\Verbs\Lifecycle\Queue as EventQueue;
 use Thunk\Verbs\Lifecycle\SnapshotStore;
@@ -68,6 +69,7 @@ class VerbsServiceProvider extends PackageServiceProvider
         $this->app->scoped(EventQueue::class);
         $this->app->scoped(EventStateRegistry::class);
         $this->app->singleton(MetadataManager::class);
+        $this->app->singleton(HandleReturnResolver::class);
 
         $this->app->scoped(StateManager::class, function (Container $app) {
             return new StateManager(

--- a/tests/Feature/HandleReturnResolutionTest.php
+++ b/tests/Feature/HandleReturnResolutionTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Thunk\Verbs\Attributes\Hooks\On;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+use Thunk\Verbs\Lifecycle\Phase;
+
+it('returns the result of the event handle method if no other hooks are registered for the event', function () {
+
+    expect(CommitResultResolverTestEventWithoutReturn::commit())
+        ->toBe(null);
+
+    expect(CommitResultResolverTestEventWithReturn::commit())
+        ->toBe(CommitResultResolverTestEventWithReturn::HANDLE_RESULT);
+});
+
+it('returns a collection of the results of all event handlers if other hooks are registered for the event', function () {
+    Verbs::listen(new CommitResultResolverTestListenerWithReturn('foo'));
+    Verbs::listen(CommitResultResolverTestListenerWithoutReturn::class);
+    Verbs::listen(new CommitResultResolverTestListenerWithReturn($expectedCollection = collect(['bar', 'baz'])));
+    Verbs::listen(new CommitResultResolverTestListenerWithReturn(null));
+    Verbs::listen(new CommitResultResolverTestListenerWithReturn($expectedCarbon = new Carbon('2025-04-01T00:00:00.123456+02:00')));
+
+    $result = CommitResultResolverTestEventWithoutReturn::commit();
+
+    expect($result)->toBeInstanceOf(Collection::class);
+
+    expect($result->all())
+        ->toBe([
+            null, // From our event without return
+            'foo', // From our listener with `foo` return
+            null, // From our listener without return
+            $expectedCollection, // From our listener with `Collection` return
+            null, // From our listener with `null` return
+            $expectedCarbon, // From our listener with `Carbon` return
+        ]);
+});
+
+it('can deterministically resolve commit return value using a global resolver callback', function () {
+    Verbs::resolveHandleReturnUsing(
+        fn (Collection $results, Event $event): Collection => $results->take(1)
+    );
+
+    Verbs::listen(new CommitResultResolverTestListenerWithoutReturn);
+    Verbs::listen(new CommitResultResolverTestListenerWithReturn('foo'));
+
+    $result = CommitResultResolverTestEventWithReturn::commit();
+
+    expect($result)->toBe(CommitResultResolverTestEventWithReturn::HANDLE_RESULT);
+});
+
+class CommitResultResolverTestEventWithoutReturn extends Event
+{
+    public function handle(): void {}
+}
+
+class CommitResultResolverTestEventWithReturn extends Event
+{
+    public const HANDLE_RESULT = 'event-handle-return';
+
+    public function handle(): mixed
+    {
+        return self::HANDLE_RESULT;
+    }
+}
+
+class CommitResultResolverTestListenerWithoutReturn
+{
+    #[On(Phase::Handle)]
+    public function handle(Event $event): void {}
+}
+
+class CommitResultResolverTestListenerWithReturn
+{
+    public function __construct(public mixed $return) {}
+
+    #[On(Phase::Handle)]
+    public function handle(Event $event): mixed
+    {
+        return $this->return;
+    }
+}


### PR DESCRIPTION
This is an attempt to address the inconsistent behavior of `Event::commit` return values in a backwards-compatible way.

The key idea is to introduce a `HandleReturnResolver` singleton that is used by the `Dispatcher`, retains the current behavior, but can be customized.

I believe this strikes a good balance between small change set and good flexibility _(i.e. by also passing the `Event` into the resolver, one could technically differentiate behavior also based on the Event class and its properties)_.

Looking forward to this being considered before a v1 tag and happy for any comments/feedback.

## References

I discussed this topic once with @DanielCoulbourne and here are some previous references:
- Issue marked as "Not Planned": https://github.com/hirethunk/verbs/issues/213
- The now superseded original PR which suggested changing the logic: https://github.com/hirethunk/verbs/pull/218

I still [strongly believe that the current default behavior is not reliable for actual use](https://github.com/hirethunk/verbs/pull/218#issuecomment-3110188942), but hope this backwards-compatible change allows people to opt-in to any behavior they want.

## Additional notes:
- There is still some "opinionated" behavior in [`PendingEvent::commit()`](https://github.com/hirethunk/verbs/blob/a0e65facd58caebe69e291c0f8754d3ce74a63db/src/Support/PendingEvent.php#L137), based on the collection size of the "last results". I address this by using `$results->take(1)` in my test example and I force a `Collection` return type in the `HandleReturnResolver` to minimize accidental misuse of the custom resolution logic.
- I updated the documentation to point out the current behavior and hint at a possible solution for people who want a consistent return value.