### PR TITLE
fix: only use PhpDocExtractor if available

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
         "phpunit/phpunit": "^10.5|^11.5.3",
         "projektgopher/whisky": "^0.5.1|^0.7"
     },
+    "suggest": {
+        "phpdocumentor/reflection-docblock": "Enables PhpDoc-based serializer type extraction (for example, `/** @var DTO[] */` collection element inference)."
+    },
     "autoload": {
         "psr-4": {
             "Thunk\\Verbs\\": "src/",

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -8,3 +8,9 @@ application. If you need to store more complex data, you may need to add your ow
 which you can do in `config/verbs.php` file. You may also change the
 [default serializer context](https://symfony.com/doc/current/components/serializer.html#context)
 there as well.
+
+For PhpDoc-based type inference (for example `/** @var MyDto[] */` on array properties),
+install `phpdocumentor/reflection-docblock`. Verbs will still work without it, but serializer
+type extraction falls back to reflection-only behavior and PhpDoc collection element types are
+not inferred during deserialization. See also [this PR](https://github.com/hirethunk/verbs/pull/125#issuecomment-2359638427),
+that introduced the PhpDoc-based type inference feature.

--- a/src/VerbsServiceProvider.php
+++ b/src/VerbsServiceProvider.php
@@ -110,10 +110,8 @@ class VerbsServiceProvider extends PackageServiceProvider
 
             return new PropertyNormalizer(
                 propertyTypeExtractor: new PropertyInfoExtractor(
-                    typeExtractors: [
-                        new PhpDocExtractor,
-                        new ReflectionExtractor,
-                    ]),
+                    typeExtractors: $this->getPropertyTypeExtractors(),
+                ),
                 classDiscriminatorResolver: new ClassDiscriminatorFromClassMetadata(new ClassMetadataFactory($loader)),
             );
         });
@@ -180,5 +178,18 @@ class VerbsServiceProvider extends PackageServiceProvider
         if ($event instanceof JobProcessed) {
             app(AutoCommitManager::class)->commitIfAutoCommitting();
         }
+    }
+
+    protected function getPropertyTypeExtractors(): array
+    {
+        return [
+            ...$this->hasPhpDocExtractorDependency() ? [new PhpDocExtractor] : [],
+            new ReflectionExtractor,
+        ];
+    }
+
+    protected function hasPhpDocExtractorDependency(): bool
+    {
+        return class_exists(PhpDocExtractor::class);
     }
 }

--- a/tests/Feature/SerializationTest.php
+++ b/tests/Feature/SerializationTest.php
@@ -12,6 +12,7 @@ use Thunk\Verbs\SerializedByVerbs;
 use Thunk\Verbs\State;
 use Thunk\Verbs\Support\Normalization\NormalizeToPropertiesAndClassName;
 use Thunk\Verbs\Support\Serializer;
+use Thunk\Verbs\VerbsServiceProvider;
 
 it('supports instantiation via an associative array', function () {
     $snowflake = Snowflake::make();
@@ -165,6 +166,39 @@ it('allows us to store a serializable class(es) as a property', function () {
 
     expect($deserialized_event->dto)->toBeInstanceOf(DTO::class)
         ->and($deserialized_event->dtos[0])->toBeInstanceOf(DTO::class);
+});
+
+it('falls back to reflection type extraction when PhpDoc extraction is unavailable', function () {
+    $provider = new class(app()) extends VerbsServiceProvider
+    {
+        protected function hasPhpDocExtractorDependency(): bool
+        {
+            return false;
+        }
+    };
+
+    $provider->packageRegistered();
+    app()->forgetInstance(Serializer::class);
+    app()->forgetInstance(PropertyNormalizer::class);
+
+    $original_event = new EventWithPhpDocArray;
+    $serialized_data = app(Serializer::class)->serialize($original_event);
+
+    $deserialized_event = app(Serializer::class)->deserialize(EventWithPhpDocArray::class, $serialized_data);
+
+    expect($deserialized_event->dto)
+        ->toBeInstanceOf(DTO::class);
+
+    // NOTE: Type inference via PhpDoc is not available, which breaks the collection type inference.
+    // See also https://github.com/hirethunk/verbs/pull/125#issuecomment-2359638427
+    expect($deserialized_event->dtos)
+        ->toBeArray()
+        ->toBe([
+            [
+                'fqcn' => DTO::class,
+                'foo' => 1,
+            ],
+        ]);
 });
 
 class EventWithConstructorPromotion extends Event


### PR DESCRIPTION
This PR makes the use of the `PhpDocExtractor` optional, as suggested by @inxilpro in the related PR: https://github.com/hirethunk/verbs/pull/210#issuecomment-2767298666

## References

- The feature was originally introduced in https://github.com/hirethunk/verbs/pull/125 to get array-of-class deserialization working properly.
- There is a related PR that suggests introducing the dependency on `phpdocumentor/reflection-docblock`: https://github.com/hirethunk/verbs/pull/210 (related PR)

## Additional Notes

⚠️ During the implementation of the change and corresponding tests, I would suggest to re-consider whether the `PhpDocExtractor` should be an optional dependency or ensures a good baseline of deserialization support. Without the `PhpDocExtractor`, arrays of classes support would effectively be lost and the question is if this is a shortcoming, or an esoteric edge-case that could be opted in. See also https://github.com/hirethunk/verbs/pull/210#issuecomment-3950235573